### PR TITLE
fixes in rnaseq mark duplicates to accommodate switch to sambamba

### DIFF
--- a/definitions/rnaseq.wdl
+++ b/definitions/rnaseq.wdl
@@ -99,8 +99,7 @@ workflow rnaseq {
 
   call mdas.markDuplicatesAndSort as markDup {
     input:
-    bam=indexBam.indexed_bam,
-    input_sort_order="coordinate"
+    bam=indexBam.indexed_bam
   }
 
   call st.stringtie {

--- a/definitions/rnaseq_star_fusion.wdl
+++ b/definitions/rnaseq_star_fusion.wdl
@@ -101,8 +101,7 @@ workflow rnaseqStarFusion {
 
   call mdas.markDuplicatesAndSort as markDup {
     input:
-    bam=sortBam.sorted_bam,
-    input_sort_order="coordinate"
+    bam=sortBam.sorted_bam
   }
 
   call ib.indexBam {

--- a/definitions/rnaseq_star_fusion_with_xenosplit.wdl
+++ b/definitions/rnaseq_star_fusion_with_xenosplit.wdl
@@ -123,8 +123,7 @@ workflow rnaseqStarFusionWithXenosplit {
 
   call mdas.markDuplicatesAndSort as markDup {
     input:
-    bam=sortBam.sorted_bam,
-    input_sort_order="coordinate"
+    bam=sortBam.sorted_bam
   }
 
   call ib.indexBam {

--- a/definitions/tools/mark_duplicates_and_sort.wdl
+++ b/definitions/tools/mark_duplicates_and_sort.wdl
@@ -6,7 +6,7 @@ task markDuplicatesAndSort {
     String output_name = "MarkedSorted.bam"
   }
   String metrics_file_name = sub(output_name, "\.bam$", ".mark_dups_metrics.txt")
-  Int space_needed_gb = 10 + round(3*size(bam, "GB"))
+  Int space_needed_gb = 10 + round(5*size(bam, "GB"))
   #estimate 15M reads per Gb size of bam
   #markdup is listed as 2Gb per 100M reads
   Int mem_needed_gb = round(((size(bam, "GB")*15)/100)*2)+20


### PR DESCRIPTION
The mark duplicates approach was updated and calls to that from DNA pipelines were updated but these RNA-seq pipelines that also involve mark duplicates were not updated.  The new approach uses sambamba.  This seems to have higher disk usage requirements so that is also being updated here.