### PR TITLE
if we are going to pick a gnomad filter gnomADe_AF is more in line wi…

### DIFF
--- a/definitions/detect_variants.wdl
+++ b/definitions/detect_variants.wdl
@@ -64,7 +64,7 @@ workflow detectVariants {
     Int? readcount_minimum_base_quality
     Int? readcount_minimum_mapping_quality
 
-    String gnomad_field_name = "gnomAD_AF"  # only change with gnomad_filter annotation
+    String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter annotation
     Float filter_gnomADe_maximum_population_allele_frequency = 0.001
     Float filter_mapq0_threshold = 0.15
     Float filter_somatic_llr_threshold = 5

--- a/definitions/detect_variants_wgs.wdl
+++ b/definitions/detect_variants_wgs.wdl
@@ -51,7 +51,7 @@ workflow detectVariantsWgs {
     String vep_pick  # enum ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     Array[String] vep_plugins = ["Frameshift", "Wildtype"]
 
-    String gnomad_field_name = "gnomAD_AF"  # only change with gnomad_filter_annotation
+    String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter_annotation
     Float filter_gnomADe_maximum_population_allele_frequency = 0.001
     Float filter_mapq0_threshold = 0.15
     Int filter_minimum_depth = 1

--- a/definitions/subworkflows/germline_detect_variants.wdl
+++ b/definitions/subworkflows/germline_detect_variants.wdl
@@ -36,7 +36,7 @@ workflow germlineDetectVariants {
     Array[String]? variants_to_table_genotype_fields
     Array[String]? vep_to_table_fields
     String final_tsv_prefix = "variants"
-    String gnomad_field_name = "gnomAD_AF"  # only change with gnomad_filter annotation
+    String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter annotation
     Float filter_gnomAD_maximum_population_allele_frequency = 0.05
   }
 

--- a/definitions/tumor_only_detect_variants.wdl
+++ b/definitions/tumor_only_detect_variants.wdl
@@ -28,7 +28,7 @@ workflow tumorOnlyDetectVariants {
     File bam
     File bam_bai
 
-    String gnomad_field_name = "gnomAD_AF"  # only change with gnomad_filter_annotation
+    String gnomad_field_name = "gnomADe_AF"  # only change with gnomad_filter_annotation
     File roi_intervals
 
     Int varscan_strand_filter = 0


### PR DESCRIPTION
…th common practice than gnomAD_AF

Ideally we would honor the selection of `gnomAD_AF`, `gnomADe_AF` or `gnomADg_AF` specified by the user in the YAML file. For example in an immuno.yaml:

```
- method: exact
  force_report_coordinates: true
  annotation:
    file: "gs://griffith-lab-workflow-inputs/human_GRCh38_ens95/known_variants/gnomad_fixed_b38_exome.vc
f.gz"
    secondary_files:
    - "gs://griffith-lab-workflow-inputs/human_GRCh38_ens95/known_variants/gnomad_fixed_b38_exome.vcf.gz.tbi"
    data_format: vcf
    name: gnomADe
    vcf_fields:
    - AF
    - AF_AFR
    - AF_AMR
    - AF_ASJ
    - AF_EAS
    - AF_FIN
    - AF_NFE
    - AF_OTH
    - AF_SAS
    gnomad_filter: true
    check_existing: true
```

Currently it doesn't seem to matter what one puts under `name` 