### PR TITLE
update command so that false is passed in correct position

### DIFF
--- a/definitions/tools/filter_vcf_cle.wdl
+++ b/definitions/tools/filter_vcf_cle.wdl
@@ -14,7 +14,7 @@ task filterVcfCle {
   }
 
   command <<<
-    /usr/bin/perl /usr/bin/docm_and_coding_indel_selection.pl ~{vcf} "$PWD" filter ~{filter}
+    /usr/bin/perl /usr/bin/docm_and_coding_indel_selection.pl ~{vcf} "$PWD" ~{filter}
   >>>
 
   output {


### PR DESCRIPTION
The structure of this command had a weird side effect.  By doing it this way the command actually comes out to: 

`/usr/bin/perl /usr/bin/docm_and_coding_indel_selection.pl mapq_filtered.vcf.gz "$PWD" filter false`

We mean for filter to be `false` and the filtering done in this script to NOT happen.  But in this command "filter" is in the third argument position, and this is exactly what the Perl script looks for to do the filtering. 

https://github.com/genome/docker-cle/blob/master/docm_and_coding_indel_selection.pl

We don't really have any intention of using this filter.  If we did, this solution wouldn't really work.  But this should produce the correct result if filtering is not desired.  We could probably just drop this step entirely.

If we wanted to fix it more completely, we need some logic so that if:
- `Boolean cle_vcf_filter = false` then we want to pass the string "false" (or nothing) 
- `Boolean cle_vcf_filter = true` then we want to pass the string "filter" 