### PR TITLE
Handling HLA Empty Fields.

### DIFF
--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -14,7 +14,7 @@ task extractHlaAlleles {
 
   String outname = "helper.txt"
   command <<<
-    /usr/bin/awk '{FS="\t";for(n=2;n<=NF-2;n++){if(n==2){printf "HLA-"$n}else{printf "\nHLA-"$n}}}' ~{file} > ~{outname}
+    /usr/bin/awk '{FS="\t";getline;for(n=2;n<=NF-2;n++){if(n==2){printf "HLA-"$n}else{printf "\nHLA-"$n}}}' ~{file} > ~{outname}
   >>>
 
   output {

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -14,7 +14,7 @@ task extractHlaAlleles {
 
   String outname = "helper.txt"
   command <<<
-    /usr/bin/awk '{getline; printf "HLA-"$2 "\nHLA-"$3 "\nHLA-"$4 "\nHLA-"$5 "\nHLA-"$6 "\nHLA-"$7}' ~{file} > ~{outname}
+    /usr/bin/awk '{FS="\t";for(n=2;n<=NF-2;n++){if(n==2){printf "HLA-"$n}else{printf "\nHLA-"$n}}}' ~{file} > ~{outname}
   >>>
 
   output {

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -14,7 +14,7 @@ task extractHlaAlleles {
 
   String outname = "helper.txt"
   command <<<
-    /usr/bin/awk '{FS="\t";getline;for(n=2;n<=NF-2;n++){if($n==""){printf ""}else{if(n==2){printf "HLA-"$n}else{printf "\nHLA-"$n}}}}' ~{file} > ~{outname}
+    /usr/bin/awk '{FS="\t";getline;for(n=2;n<=NF-2;n++){if($n==""){}else{printf "HLA-"$n"\n"}}}' ~{file} > ~{outname}
   >>>
 
   output {

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -14,7 +14,7 @@ task extractHlaAlleles {
 
   String outname = "helper.txt"
   command <<<
-    /usr/bin/awk '{FS="\t";getline;for(n=2;n<=NF-2;n++){if(n==2){printf "HLA-"$n}else{printf "\nHLA-"$n}}}' ~{file} > ~{outname}
+    /usr/bin/awk '{FS="\t";getline;for(n=2;n<=NF-2;n++){if($n==""){printf ""}else{if(n==2){printf "HLA-"$n}else{printf "\nHLA-"$n}}}}' ~{file} > ~{outname}
   >>>
 
   output {


### PR DESCRIPTION

By adding a Field Separator of `\t`, awk can return empty positional arguments. If it is empty, do nothing. Otherwise, print it.

`awk '{FS="\t";getline;for(n=2;n<=NF-2;n++){if($n==""){}else{printf "HLA-"$n"\n"}}}'`

