### PR TITLE
Fix for new shell script version of mapq0 filter from 0.5.2

### DIFF
--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -23,7 +23,7 @@ task filterVcfMapq0 {
 
   String outfile = "mapq_filtered.vcf.gz"
   command <<<
-    /bin/bash /usr/bin/mapq0_vcf_filter.sh ~{outfile} ~{vcf} ~{tumor_bam} ~{reference} ~{threshold}
+    /bin/bash /usr/bin/mapq0_vcf_filter.sh `pwd` ~{vcf} ~{tumor_bam} ~{reference} ~{threshold}
   >>>
 
   output {


### PR DESCRIPTION
The updated docker takes a directory as a parameter instead of the filename itself.  The CWL version had already been updated but this one missed the update to 0.5.2 so the update to 0.5.3 needs to include this.