### PR TITLE
Set localization_optional on inputs for some GATK and samtools calls.

### DIFF
--- a/definitions/tools/docm_gatk_haplotype_caller.wdl
+++ b/definitions/tools/docm_gatk_haplotype_caller.wdl
@@ -14,6 +14,13 @@ task docmGatkHaplotypeCaller {
     File interval_list
   }
 
+  parameter_meta {
+    bam: { localization_optional: true }
+    bam_bai: { localization_optional: true }
+    normal_bam: { localization_optional: true }
+    normal_bam_bai: { localization_optional: true }
+  }
+
   Float copied_size = size([docm_vcf, interval_list], "GB")
   Int space_needed_gb = 10 + round(copied_size*3 + size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, bam, bam_bai, docm_vcf_tbi], "GB"))
   runtime {

--- a/definitions/tools/downsample.wdl
+++ b/definitions/tools/downsample.wdl
@@ -11,6 +11,10 @@ task downsample {
     String? strategy  # enum [HighAccuracy, ConstantMemory, Chained]
   }
 
+  parameter_meta {
+    sam: { localization_optional: true }
+  }
+
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + size(sam, "GB") * 2)
   runtime {

--- a/definitions/tools/samtools_flagstat.wdl
+++ b/definitions/tools/samtools_flagstat.wdl
@@ -6,6 +6,11 @@ task samtoolsFlagstat {
     File bam_bai
   }
 
+  parameter_meta {
+    bam: { localization_optional: true }
+    bam_bai: { localization_optional: true }
+  }
+
   Int space_needed_gb = 10 + round(size([bam, bam_bai], "GB")*2)
   runtime {
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
@@ -15,6 +20,13 @@ task samtoolsFlagstat {
 
   String outfile = basename(bam) + ".flagstat"
   command <<<
+    ACCESS_TOKEN=$(wget -O - --header "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token?alt=text 2> /dev/null | grep access_token)
+    if [[ "$ACCESS_TOKEN" == "access_token"* ]]; then
+       # When the BAMs aren't localized in GCP, samtools needs this token to access them via gs:// URLs.
+       export GCS_OAUTH_TOKEN=$(echo "$ACCESS_TOKEN" | cut -d ' ' -f 2 )
+       echo "got token" ${GCS_OAUTH_TOKEN:0:5}
+    fi
+
     /usr/local/bin/samtools flagstat ~{bam} > ~{outfile}
   >>>
 

--- a/definitions/tools/select_variants.wdl
+++ b/definitions/tools/select_variants.wdl
@@ -18,6 +18,11 @@ task selectVariants {
     String? select_type
   }
 
+  parameter_meta {
+    vcf: { localization_optional: true }
+    vcf_tbi: { localization_optional: true }
+  }
+
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB")*3 + size([reference, reference_fai, reference_dict, interval_list], "GB"))
   runtime {
     docker: "broadinstitute/gatk:4.1.8.1"

--- a/definitions/tools/variants_to_table.wdl
+++ b/definitions/tools/variants_to_table.wdl
@@ -11,6 +11,11 @@ task variantsToTable {
     Array[String] genotype_fields = ["GT", "AD", "DP", "AF"]
   }
 
+  parameter_meta {
+    vcf: { localization_optional: true }
+    vcf_tbi: { localization_optional: true }
+  }
+
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Float vcf_size = size([vcf, vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(vcf_size*2 + reference_size)


### PR DESCRIPTION
Others in the pipeline are still using older versions, so they'll need to be upgraded first to support this option.

I almost have a successful immuno.wdl run with these changes, but it failed for an unrelated reason that'll need fixing... so the part after all variant filtering hasn't been tested with this yet.

[This is part of #64, but I think it'd be good to do a pass of upgrading some of the aforementioned pipeline steps (especially varscan) before calling that one completed.  The existing changes here are valuable on their own, though, so if this PR looks good we can get the improvements to mutect et al. now while waiting on that.]