### PR TITLE
added new runtime attributes to all tasks

### DIFF
--- a/definitions/tools/add_strelka_gt.wdl
+++ b/definitions/tools/add_strelka_gt.wdl
@@ -7,7 +7,6 @@ task addStrelkaGt {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_strelka_gt.wdl
+++ b/definitions/tools/add_strelka_gt.wdl
@@ -7,6 +7,7 @@ task addStrelkaGt {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:bionic"

--- a/definitions/tools/add_strelka_gt.wdl
+++ b/definitions/tools/add_strelka_gt.wdl
@@ -7,6 +7,7 @@ task addStrelkaGt {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_strelka_gt.wdl
+++ b/definitions/tools/add_strelka_gt.wdl
@@ -7,7 +7,6 @@ task addStrelkaGt {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:bionic"

--- a/definitions/tools/add_strelka_gt.wdl
+++ b/definitions/tools/add_strelka_gt.wdl
@@ -7,6 +7,8 @@ task addStrelkaGt {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "ubuntu:bionic"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/add_string_at_line.wdl
+++ b/definitions/tools/add_string_at_line.wdl
@@ -10,7 +10,6 @@ task addStringAtLine {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_string_at_line.wdl
+++ b/definitions/tools/add_string_at_line.wdl
@@ -10,6 +10,8 @@ task addStringAtLine {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "ubuntu:xenial"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/add_string_at_line.wdl
+++ b/definitions/tools/add_string_at_line.wdl
@@ -10,6 +10,7 @@ task addStringAtLine {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:xenial"

--- a/definitions/tools/add_string_at_line.wdl
+++ b/definitions/tools/add_string_at_line.wdl
@@ -10,6 +10,7 @@ task addStringAtLine {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_string_at_line.wdl
+++ b/definitions/tools/add_string_at_line.wdl
@@ -10,7 +10,6 @@ task addStringAtLine {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:xenial"

--- a/definitions/tools/add_string_at_line_bgzipped.wdl
+++ b/definitions/tools/add_string_at_line_bgzipped.wdl
@@ -10,6 +10,7 @@ task addStringAtLineBgzipped {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_string_at_line_bgzipped.wdl
+++ b/definitions/tools/add_string_at_line_bgzipped.wdl
@@ -10,6 +10,7 @@ task addStringAtLineBgzipped {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11-h6270b1f_0"

--- a/definitions/tools/add_string_at_line_bgzipped.wdl
+++ b/definitions/tools/add_string_at_line_bgzipped.wdl
@@ -10,7 +10,6 @@ task addStringAtLineBgzipped {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_string_at_line_bgzipped.wdl
+++ b/definitions/tools/add_string_at_line_bgzipped.wdl
@@ -10,6 +10,8 @@ task addStringAtLineBgzipped {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11-h6270b1f_0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/add_string_at_line_bgzipped.wdl
+++ b/definitions/tools/add_string_at_line_bgzipped.wdl
@@ -10,7 +10,6 @@ task addStringAtLineBgzipped {
 
   Int space_needed_gb = 10 + round(2*size(input_file, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11-h6270b1f_0"

--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -10,6 +10,7 @@ task addVepFieldsToTable {
 
   Int space_needed_gb = 10 + round(size([vcf, tsv], "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -10,7 +10,6 @@ task addVepFieldsToTable {
 
   Int space_needed_gb = 10 + round(size([vcf, tsv], "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -10,6 +10,7 @@ task addVepFieldsToTable {
 
   Int space_needed_gb = 10 + round(size([vcf, tsv], "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -10,7 +10,6 @@ task addVepFieldsToTable {
 
   Int space_needed_gb = 10 + round(size([vcf, tsv], "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -10,6 +10,8 @@ task addVepFieldsToTable {
 
   Int space_needed_gb = 10 + round(size([vcf, tsv], "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "griffithlab/vatools:4.1.0"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/agfusion.wdl
+++ b/definitions/tools/agfusion.wdl
@@ -9,7 +9,6 @@ task agfusion {
   }
 
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/agfusion.wdl
+++ b/definitions/tools/agfusion.wdl
@@ -9,6 +9,7 @@ task agfusion {
   }
 
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/agfusion.wdl
+++ b/definitions/tools/agfusion.wdl
@@ -9,6 +9,7 @@ task agfusion {
   }
 
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/agfusion:1.3.1-ensembl-105"

--- a/definitions/tools/agfusion.wdl
+++ b/definitions/tools/agfusion.wdl
@@ -9,6 +9,8 @@ task agfusion {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/agfusion:1.3.1-ensembl-105"
     memory: "32GB"
     cpu: 4

--- a/definitions/tools/agfusion.wdl
+++ b/definitions/tools/agfusion.wdl
@@ -9,7 +9,6 @@ task agfusion {
   }
 
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/agfusion:1.3.1-ensembl-105"

--- a/definitions/tools/annotsv.wdl
+++ b/definitions/tools/annotsv.wdl
@@ -10,6 +10,7 @@ task annotsv {
 
   Int space_needed_gb = 10 + round(size(snps_vcf, "GB") + size(input_vcf, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/annotsv.wdl
+++ b/definitions/tools/annotsv.wdl
@@ -10,6 +10,7 @@ task annotsv {
 
   Int space_needed_gb = 10 + round(size(snps_vcf, "GB") + size(input_vcf, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/annotsv.wdl
+++ b/definitions/tools/annotsv.wdl
@@ -10,7 +10,6 @@ task annotsv {
 
   Int space_needed_gb = 10 + round(size(snps_vcf, "GB") + size(input_vcf, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/annotsv.wdl
+++ b/definitions/tools/annotsv.wdl
@@ -10,6 +10,8 @@ task annotsv {
 
   Int space_needed_gb = 10 + round(size(snps_vcf, "GB") + size(input_vcf, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "8GB"
     docker: "mgibio/annotsv-cwl:2.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/annotsv.wdl
+++ b/definitions/tools/annotsv.wdl
@@ -10,7 +10,6 @@ task annotsv {
 
   Int space_needed_gb = 10 + round(size(snps_vcf, "GB") + size(input_vcf, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/annotsv_filter.wdl
+++ b/definitions/tools/annotsv_filter.wdl
@@ -11,6 +11,7 @@ task annotsvFilter {
 
   Int space_needed_gb = 10 + round(2*size(annotsv_tsv, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/annotsv_filter.wdl
+++ b/definitions/tools/annotsv_filter.wdl
@@ -11,7 +11,6 @@ task annotsvFilter {
 
   Int space_needed_gb = 10 + round(2*size(annotsv_tsv, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/annotsv_filter.wdl
+++ b/definitions/tools/annotsv_filter.wdl
@@ -11,7 +11,6 @@ task annotsvFilter {
 
   Int space_needed_gb = 10 + round(2*size(annotsv_tsv, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/annotsv_filter.wdl
+++ b/definitions/tools/annotsv_filter.wdl
@@ -11,6 +11,8 @@ task annotsvFilter {
 
   Int space_needed_gb = 10 + round(2*size(annotsv_tsv, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "python:3"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/annotsv_filter.wdl
+++ b/definitions/tools/annotsv_filter.wdl
@@ -11,6 +11,7 @@ task annotsvFilter {
 
   Int space_needed_gb = 10 + round(2*size(annotsv_tsv, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/bam_readcount.wdl
+++ b/definitions/tools/bam_readcount.wdl
@@ -16,6 +16,8 @@ task bamReadcount {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict, vcf], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/bam_readcount_helper-cwl:1.1.1"
     memory: "16GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/bam_readcount.wdl
+++ b/definitions/tools/bam_readcount.wdl
@@ -16,6 +16,7 @@ task bamReadcount {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict, vcf], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bam_readcount_helper-cwl:1.1.1"

--- a/definitions/tools/bam_readcount.wdl
+++ b/definitions/tools/bam_readcount.wdl
@@ -16,6 +16,7 @@ task bamReadcount {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict, vcf], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_readcount.wdl
+++ b/definitions/tools/bam_readcount.wdl
@@ -16,7 +16,6 @@ task bamReadcount {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict, vcf], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_readcount.wdl
+++ b/definitions/tools/bam_readcount.wdl
@@ -16,7 +16,6 @@ task bamReadcount {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict, vcf], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bam_readcount_helper-cwl:1.1.1"

--- a/definitions/tools/bam_to_bigwig.wdl
+++ b/definitions/tools/bam_to_bigwig.wdl
@@ -13,6 +13,7 @@ task bamToBigwig {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(3*bam_size_gb + reference_size_gb)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/bam_to_bigwig.wdl
+++ b/definitions/tools/bam_to_bigwig.wdl
@@ -13,7 +13,6 @@ task bamToBigwig {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(3*bam_size_gb + reference_size_gb)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_to_bigwig.wdl
+++ b/definitions/tools/bam_to_bigwig.wdl
@@ -13,7 +13,6 @@ task bamToBigwig {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(3*bam_size_gb + reference_size_gb)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/bam_to_bigwig.wdl
+++ b/definitions/tools/bam_to_bigwig.wdl
@@ -13,6 +13,7 @@ task bamToBigwig {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(3*bam_size_gb + reference_size_gb)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_to_bigwig.wdl
+++ b/definitions/tools/bam_to_bigwig.wdl
@@ -13,6 +13,8 @@ task bamToBigwig {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(3*bam_size_gb + reference_size_gb)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "32GB"
     docker: "quay.io/biocontainers/cgpbigwig:1.4.0--h93d22ca_0"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/bam_to_cram.wdl
+++ b/definitions/tools/bam_to_cram.wdl
@@ -15,7 +15,6 @@ task bamToCram {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int size_needed_gb = 10 + round(size(bam, "GB") * 2 + reference_size)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_to_cram.wdl
+++ b/definitions/tools/bam_to_cram.wdl
@@ -15,6 +15,7 @@ task bamToCram {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int size_needed_gb = 10 + round(size(bam, "GB") * 2 + reference_size)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_to_cram.wdl
+++ b/definitions/tools/bam_to_cram.wdl
@@ -15,6 +15,7 @@ task bamToCram {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int size_needed_gb = 10 + round(size(bam, "GB") * 2 + reference_size)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/bam_to_cram.wdl
+++ b/definitions/tools/bam_to_cram.wdl
@@ -15,6 +15,8 @@ task bamToCram {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int size_needed_gb = 10 + round(size(bam, "GB") * 2 + reference_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
     memory: "4GB"
     disks: "local-disk ~{size_needed_gb} HDD"

--- a/definitions/tools/bam_to_cram.wdl
+++ b/definitions/tools/bam_to_cram.wdl
@@ -15,7 +15,6 @@ task bamToCram {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int size_needed_gb = 10 + round(size(bam, "GB") * 2 + reference_size)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/bam_to_fastq.wdl
+++ b/definitions/tools/bam_to_fastq.wdl
@@ -6,7 +6,6 @@ task bamToFastq {
   # ran into issue at 3*, bump to 10*
   Int space_needed_gb = 10 + round(10*size(bam, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bam_to_fastq.wdl
+++ b/definitions/tools/bam_to_fastq.wdl
@@ -6,6 +6,7 @@ task bamToFastq {
   # ran into issue at 3*, bump to 10*
   Int space_needed_gb = 10 + round(10*size(bam, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/rnaseq:1.0.0"

--- a/definitions/tools/bam_to_fastq.wdl
+++ b/definitions/tools/bam_to_fastq.wdl
@@ -6,6 +6,8 @@ task bamToFastq {
   # ran into issue at 3*, bump to 10*
   Int space_needed_gb = 10 + round(10*size(bam, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/rnaseq:1.0.0"
     cpu: 1
     memory: "6GB"

--- a/definitions/tools/bam_to_fastq.wdl
+++ b/definitions/tools/bam_to_fastq.wdl
@@ -6,7 +6,6 @@ task bamToFastq {
   # ran into issue at 3*, bump to 10*
   Int space_needed_gb = 10 + round(10*size(bam, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/rnaseq:1.0.0"

--- a/definitions/tools/bam_to_fastq.wdl
+++ b/definitions/tools/bam_to_fastq.wdl
@@ -6,6 +6,7 @@ task bamToFastq {
   # ran into issue at 3*, bump to 10*
   Int space_needed_gb = 10 + round(10*size(bam, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bcftools_merge.wdl
+++ b/definitions/tools/bcftools_merge.wdl
@@ -12,7 +12,6 @@ task bcftoolsMerge {
 
   Int space_needed_gb = 10 + round(2 * size(vcfs, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/bcftools_merge.wdl
+++ b/definitions/tools/bcftools_merge.wdl
@@ -12,6 +12,7 @@ task bcftoolsMerge {
 
   Int space_needed_gb = 10 + round(2 * size(vcfs, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/bcftools_merge.wdl
+++ b/definitions/tools/bcftools_merge.wdl
@@ -12,7 +12,6 @@ task bcftoolsMerge {
 
   Int space_needed_gb = 10 + round(2 * size(vcfs, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bcftools_merge.wdl
+++ b/definitions/tools/bcftools_merge.wdl
@@ -12,6 +12,7 @@ task bcftoolsMerge {
 
   Int space_needed_gb = 10 + round(2 * size(vcfs, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bcftools_merge.wdl
+++ b/definitions/tools/bcftools_merge.wdl
@@ -12,6 +12,8 @@ task bcftoolsMerge {
 
   Int space_needed_gb = 10 + round(2 * size(vcfs, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibio/bcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/bedgraph_to_bigwig.wdl
+++ b/definitions/tools/bedgraph_to_bigwig.wdl
@@ -8,7 +8,6 @@ task bedgraphToBigwig {
 
   Int space_needed_gb = 10 + round(size(methylation_bedgraph, "GB") + size(reference_sizes, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bisulfite:v1.4"

--- a/definitions/tools/bedgraph_to_bigwig.wdl
+++ b/definitions/tools/bedgraph_to_bigwig.wdl
@@ -8,6 +8,8 @@ task bedgraphToBigwig {
 
   Int space_needed_gb = 10 + round(size(methylation_bedgraph, "GB") + size(reference_sizes, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/bisulfite:v1.4"
     memory: "32GB"
     cpu: 1

--- a/definitions/tools/bedgraph_to_bigwig.wdl
+++ b/definitions/tools/bedgraph_to_bigwig.wdl
@@ -8,6 +8,7 @@ task bedgraphToBigwig {
 
   Int space_needed_gb = 10 + round(size(methylation_bedgraph, "GB") + size(reference_sizes, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bedgraph_to_bigwig.wdl
+++ b/definitions/tools/bedgraph_to_bigwig.wdl
@@ -8,6 +8,7 @@ task bedgraphToBigwig {
 
   Int space_needed_gb = 10 + round(size(methylation_bedgraph, "GB") + size(reference_sizes, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bisulfite:v1.4"

--- a/definitions/tools/bedgraph_to_bigwig.wdl
+++ b/definitions/tools/bedgraph_to_bigwig.wdl
@@ -8,7 +8,6 @@ task bedgraphToBigwig {
 
   Int space_needed_gb = 10 + round(size(methylation_bedgraph, "GB") + size(reference_sizes, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bgzip.wdl
+++ b/definitions/tools/bgzip.wdl
@@ -7,6 +7,7 @@ task bgzip {
 
   Int space_needed_gb = 10 + round(size(file, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/bgzip.wdl
+++ b/definitions/tools/bgzip.wdl
@@ -7,6 +7,8 @@ task bgzip {
 
   Int space_needed_gb = 10 + round(size(file, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/bgzip.wdl
+++ b/definitions/tools/bgzip.wdl
@@ -7,7 +7,6 @@ task bgzip {
 
   Int space_needed_gb = 10 + round(size(file, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/bgzip.wdl
+++ b/definitions/tools/bgzip.wdl
@@ -7,6 +7,7 @@ task bgzip {
 
   Int space_needed_gb = 10 + round(size(file, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bgzip.wdl
+++ b/definitions/tools/bgzip.wdl
@@ -7,7 +7,6 @@ task bgzip {
 
   Int space_needed_gb = 10 + round(size(file, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/biscuit_align.wdl
+++ b/definitions/tools/biscuit_align.wdl
@@ -11,6 +11,7 @@ task biscuitAlign {
   Int cores = 12
   Int space_needed_gb = 10 + round(2*size([reference_index, fastq1, fastq2], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/biscuit_align.wdl
+++ b/definitions/tools/biscuit_align.wdl
@@ -11,6 +11,8 @@ task biscuitAlign {
   Int cores = 12
   Int space_needed_gb = 10 + round(2*size([reference_index, fastq1, fastq2], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "32GB"
     cpu: cores
     docker: "mgibio/biscuit:0.3.8"

--- a/definitions/tools/biscuit_align.wdl
+++ b/definitions/tools/biscuit_align.wdl
@@ -11,7 +11,6 @@ task biscuitAlign {
   Int cores = 12
   Int space_needed_gb = 10 + round(2*size([reference_index, fastq1, fastq2], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/biscuit_align.wdl
+++ b/definitions/tools/biscuit_align.wdl
@@ -11,7 +11,6 @@ task biscuitAlign {
   Int cores = 12
   Int space_needed_gb = 10 + round(2*size([reference_index, fastq1, fastq2], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/biscuit_align.wdl
+++ b/definitions/tools/biscuit_align.wdl
@@ -11,6 +11,7 @@ task biscuitAlign {
   Int cores = 12
   Int space_needed_gb = 10 + round(2*size([reference_index, fastq1, fastq2], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/biscuit_markdup.wdl
+++ b/definitions/tools/biscuit_markdup.wdl
@@ -9,6 +9,7 @@ task biscuitMarkdup {
   Int cores = 4
   Int space_needed_gb = 10 + round(2*size(bam, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     cpu: cores

--- a/definitions/tools/biscuit_markdup.wdl
+++ b/definitions/tools/biscuit_markdup.wdl
@@ -9,6 +9,7 @@ task biscuitMarkdup {
   Int cores = 4
   Int space_needed_gb = 10 + round(2*size(bam, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/biscuit_markdup.wdl
+++ b/definitions/tools/biscuit_markdup.wdl
@@ -9,7 +9,6 @@ task biscuitMarkdup {
   Int cores = 4
   Int space_needed_gb = 10 + round(2*size(bam, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     cpu: cores

--- a/definitions/tools/biscuit_markdup.wdl
+++ b/definitions/tools/biscuit_markdup.wdl
@@ -9,6 +9,8 @@ task biscuitMarkdup {
   Int cores = 4
   Int space_needed_gb = 10 + round(2*size(bam, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     cpu: cores
     memory: "24GB"
     docker: "mgibio/biscuit:0.3.8"

--- a/definitions/tools/biscuit_markdup.wdl
+++ b/definitions/tools/biscuit_markdup.wdl
@@ -9,7 +9,6 @@ task biscuitMarkdup {
   Int cores = 4
   Int space_needed_gb = 10 + round(2*size(bam, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/biscuit_pileup.wdl
+++ b/definitions/tools/biscuit_pileup.wdl
@@ -10,6 +10,8 @@ task biscuitPileup {
 
   Int space_needed_gb = 10 + round(2*size([bam, reference], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "48GB"
     cpu: cores
     docker: "mgibio/biscuit:0.3.8"

--- a/definitions/tools/biscuit_pileup.wdl
+++ b/definitions/tools/biscuit_pileup.wdl
@@ -10,6 +10,7 @@ task biscuitPileup {
 
   Int space_needed_gb = 10 + round(2*size([bam, reference], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/biscuit_pileup.wdl
+++ b/definitions/tools/biscuit_pileup.wdl
@@ -10,7 +10,6 @@ task biscuitPileup {
 
   Int space_needed_gb = 10 + round(2*size([bam, reference], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "48GB"

--- a/definitions/tools/biscuit_pileup.wdl
+++ b/definitions/tools/biscuit_pileup.wdl
@@ -10,6 +10,7 @@ task biscuitPileup {
 
   Int space_needed_gb = 10 + round(2*size([bam, reference], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "48GB"

--- a/definitions/tools/biscuit_pileup.wdl
+++ b/definitions/tools/biscuit_pileup.wdl
@@ -10,7 +10,6 @@ task biscuitPileup {
 
   Int space_needed_gb = 10 + round(2*size([bam, reference], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bisulfite_qc.wdl
+++ b/definitions/tools/bisulfite_qc.wdl
@@ -11,7 +11,6 @@ task bisulfiteQc {
 
   Int space_needed_gb = 10 + round(size([vcf, bam, reference, reference_fai, QCannotation], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     cpu: 1

--- a/definitions/tools/bisulfite_qc.wdl
+++ b/definitions/tools/bisulfite_qc.wdl
@@ -11,6 +11,7 @@ task bisulfiteQc {
 
   Int space_needed_gb = 10 + round(size([vcf, bam, reference, reference_fai, QCannotation], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     cpu: 1

--- a/definitions/tools/bisulfite_qc.wdl
+++ b/definitions/tools/bisulfite_qc.wdl
@@ -11,7 +11,6 @@ task bisulfiteQc {
 
   Int space_needed_gb = 10 + round(size([vcf, bam, reference, reference_fai, QCannotation], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bisulfite_qc.wdl
+++ b/definitions/tools/bisulfite_qc.wdl
@@ -11,6 +11,7 @@ task bisulfiteQc {
 
   Int space_needed_gb = 10 + round(size([vcf, bam, reference, reference_fai, QCannotation], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bisulfite_qc.wdl
+++ b/definitions/tools/bisulfite_qc.wdl
@@ -11,6 +11,8 @@ task bisulfiteQc {
 
   Int space_needed_gb = 10 + round(size([vcf, bam, reference, reference_fai, QCannotation], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     cpu: 1
     memory: "16GB"
     bootDiskSizeGb: 20

--- a/definitions/tools/bisulfite_vcf2bed.wdl
+++ b/definitions/tools/bisulfite_vcf2bed.wdl
@@ -10,6 +10,8 @@ task bisulfiteVcf2bed {
 
   Int space_needed_gb = 10 + round(size([vcf, reference], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/biscuit:0.3.8"
     memory: "16GB"
     cpu: 2

--- a/definitions/tools/bisulfite_vcf2bed.wdl
+++ b/definitions/tools/bisulfite_vcf2bed.wdl
@@ -10,6 +10,7 @@ task bisulfiteVcf2bed {
 
   Int space_needed_gb = 10 + round(size([vcf, reference], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/biscuit:0.3.8"

--- a/definitions/tools/bisulfite_vcf2bed.wdl
+++ b/definitions/tools/bisulfite_vcf2bed.wdl
@@ -10,6 +10,7 @@ task bisulfiteVcf2bed {
 
   Int space_needed_gb = 10 + round(size([vcf, reference], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bisulfite_vcf2bed.wdl
+++ b/definitions/tools/bisulfite_vcf2bed.wdl
@@ -10,7 +10,6 @@ task bisulfiteVcf2bed {
 
   Int space_needed_gb = 10 + round(size([vcf, reference], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/biscuit:0.3.8"

--- a/definitions/tools/bisulfite_vcf2bed.wdl
+++ b/definitions/tools/bisulfite_vcf2bed.wdl
@@ -10,7 +10,6 @@ task bisulfiteVcf2bed {
 
   Int space_needed_gb = 10 + round(size([vcf, reference], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bqsr.wdl
+++ b/definitions/tools/bqsr.wdl
@@ -130,6 +130,7 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -161,6 +162,7 @@ task bqsr {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(known_sites_size  + bam_size + reference_size)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -198,6 +200,7 @@ task GatherBqsrReports {
       -O bqsr_report.txt
   }
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -227,6 +230,7 @@ task applyBqsr {
 
   Int space_needed_gb = 10 + round(size([bqsr_table, reference, reference_fai, reference_dict], "GB") + size([bam, bam_bai], "GB") * 2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -263,6 +267,7 @@ task GatherBamFiles {
   Int command_mem_gb = ceil(mem_size_gb) - 1
   Int space_needed_gb = 10 + round(bam_size * 2.5)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/bqsr.wdl
+++ b/definitions/tools/bqsr.wdl
@@ -130,7 +130,6 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
-    preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
     docker: "python:2.7"
@@ -160,7 +159,6 @@ task bqsr {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(known_sites_size  + bam_size + reference_size)
   runtime {
-    preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
     memory: "6GB"
@@ -196,7 +194,6 @@ task GatherBqsrReports {
       -O bqsr_report.txt
   }
   runtime {
-    preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
     docker: "broadinstitute/gatk:4.1.8.1"
@@ -259,7 +256,6 @@ task GatherBamFiles {
   Int command_mem_gb = ceil(mem_size_gb) - 1
   Int space_needed_gb = 10 + round(bam_size * 2.5)
   runtime {
-    preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
     docker: "broadinstitute/gatk:4.1.8.1"

--- a/definitions/tools/bqsr.wdl
+++ b/definitions/tools/bqsr.wdl
@@ -130,6 +130,8 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
+    preemptible: 1
+    maxRetries: 2
     preemptible: preemptible_tries
     docker: "python:2.7"
     memory: "2 GiB"
@@ -158,6 +160,8 @@ task bqsr {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(known_sites_size  + bam_size + reference_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
     memory: "6GB"
     disks: "local-disk ~{space_needed_gb} SSD"
@@ -192,6 +196,8 @@ task GatherBqsrReports {
       -O bqsr_report.txt
   }
   runtime {
+    preemptible: 1
+    maxRetries: 2
     preemptible: preemptible_tries
     docker: "broadinstitute/gatk:4.1.8.1"
     memory: "4 GiB"
@@ -218,6 +224,8 @@ task applyBqsr {
 
   Int space_needed_gb = 10 + round(size([bqsr_table, reference, reference_fai, reference_dict], "GB") + size([bam, bam_bai], "GB") * 2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
     memory: "18GB"
     disks: "local-disk ~{space_needed_gb} SSD"
@@ -251,6 +259,8 @@ task GatherBamFiles {
   Int command_mem_gb = ceil(mem_size_gb) - 1
   Int space_needed_gb = 10 + round(bam_size * 2.5)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     preemptible: preemptible_tries
     docker: "broadinstitute/gatk:4.1.8.1"
     memory: "3 GiB"

--- a/definitions/tools/bqsr.wdl
+++ b/definitions/tools/bqsr.wdl
@@ -130,6 +130,7 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
@@ -160,6 +161,7 @@ task bqsr {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(known_sites_size  + bam_size + reference_size)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
@@ -196,6 +198,7 @@ task GatherBqsrReports {
       -O bqsr_report.txt
   }
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
@@ -224,6 +227,7 @@ task applyBqsr {
 
   Int space_needed_gb = 10 + round(size([bqsr_table, reference, reference_fai, reference_dict], "GB") + size([bam, bam_bai], "GB") * 2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
@@ -259,6 +263,7 @@ task GatherBamFiles {
   Int command_mem_gb = ceil(mem_size_gb) - 1
   Int space_needed_gb = 10 + round(bam_size * 2.5)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries

--- a/definitions/tools/bqsr.wdl
+++ b/definitions/tools/bqsr.wdl
@@ -130,7 +130,6 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
@@ -161,7 +160,6 @@ task bqsr {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(known_sites_size  + bam_size + reference_size)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
@@ -198,7 +196,6 @@ task GatherBqsrReports {
       -O bqsr_report.txt
   }
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries
@@ -227,7 +224,6 @@ task applyBqsr {
 
   Int space_needed_gb = 10 + round(size([bqsr_table, reference, reference_fai, reference_dict], "GB") + size([bam, bam_bai], "GB") * 2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
@@ -263,7 +259,6 @@ task GatherBamFiles {
   Int command_mem_gb = ceil(mem_size_gb) - 1
   Int space_needed_gb = 10 + round(bam_size * 2.5)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     preemptible: preemptible_tries

--- a/definitions/tools/bqsr.wdl
+++ b/definitions/tools/bqsr.wdl
@@ -130,7 +130,6 @@ task CreateSequenceGroupingTSV {
     CODE
   >>>
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -162,7 +161,6 @@ task bqsr {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(known_sites_size  + bam_size + reference_size)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -200,7 +198,6 @@ task GatherBqsrReports {
       -O bqsr_report.txt
   }
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -230,7 +227,6 @@ task applyBqsr {
 
   Int space_needed_gb = 10 + round(size([bqsr_table, reference, reference_fai, reference_dict], "GB") + size([bam, bam_bai], "GB") * 2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2
@@ -267,7 +263,6 @@ task GatherBamFiles {
   Int command_mem_gb = ceil(mem_size_gb) - 1
   Int space_needed_gb = 10 + round(bam_size * 2.5)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cat_all.wdl
+++ b/definitions/tools/cat_all.wdl
@@ -7,6 +7,8 @@ task catAll {
 
   Int space_needed_gb = 10 + round(size(region_pindel_outs, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "ubuntu:xenial"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/cat_all.wdl
+++ b/definitions/tools/cat_all.wdl
@@ -7,6 +7,7 @@ task catAll {
 
   Int space_needed_gb = 10 + round(size(region_pindel_outs, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cat_all.wdl
+++ b/definitions/tools/cat_all.wdl
@@ -7,7 +7,6 @@ task catAll {
 
   Int space_needed_gb = 10 + round(size(region_pindel_outs, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/cat_all.wdl
+++ b/definitions/tools/cat_all.wdl
@@ -7,7 +7,6 @@ task catAll {
 
   Int space_needed_gb = 10 + round(size(region_pindel_outs, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cat_all.wdl
+++ b/definitions/tools/cat_all.wdl
@@ -7,6 +7,7 @@ task catAll {
 
   Int space_needed_gb = 10 + round(size(region_pindel_outs, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/cat_out.wdl
+++ b/definitions/tools/cat_out.wdl
@@ -7,6 +7,7 @@ task catOut {
 
   Int space_needed_gb = 10 + round(size(pindel_outs, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cat_out.wdl
+++ b/definitions/tools/cat_out.wdl
@@ -7,7 +7,6 @@ task catOut {
 
   Int space_needed_gb = 10 + round(size(pindel_outs, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/cat_out.wdl
+++ b/definitions/tools/cat_out.wdl
@@ -7,7 +7,6 @@ task catOut {
 
   Int space_needed_gb = 10 + round(size(pindel_outs, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cat_out.wdl
+++ b/definitions/tools/cat_out.wdl
@@ -7,6 +7,7 @@ task catOut {
 
   Int space_needed_gb = 10 + round(size(pindel_outs, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/cat_out.wdl
+++ b/definitions/tools/cat_out.wdl
@@ -7,6 +7,8 @@ task catOut {
 
   Int space_needed_gb = 10 + round(size(pindel_outs, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "ubuntu:xenial"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/cnvkit_batch.wdl
+++ b/definitions/tools/cnvkit_batch.wdl
@@ -21,6 +21,7 @@ task cnvkitBatch {
 
   Int size_needed_gb = 10 + round(size([tumor_bam, bait_intervals, access, normal_bam, reference_fasta, reference_cnn], "GB") * 2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/cnvkit_batch.wdl
+++ b/definitions/tools/cnvkit_batch.wdl
@@ -21,6 +21,8 @@ task cnvkitBatch {
 
   Int size_needed_gb = 10 + round(size([tumor_bam, bait_intervals, access, normal_bam, reference_fasta, reference_cnn], "GB") * 2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     cpu: 1
     # We use a forked cnvkit so we can get access to root privileges

--- a/definitions/tools/cnvkit_batch.wdl
+++ b/definitions/tools/cnvkit_batch.wdl
@@ -21,7 +21,6 @@ task cnvkitBatch {
 
   Int size_needed_gb = 10 + round(size([tumor_bam, bait_intervals, access, normal_bam, reference_fasta, reference_cnn], "GB") * 2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cnvkit_batch.wdl
+++ b/definitions/tools/cnvkit_batch.wdl
@@ -21,7 +21,6 @@ task cnvkitBatch {
 
   Int size_needed_gb = 10 + round(size([tumor_bam, bait_intervals, access, normal_bam, reference_fasta, reference_cnn], "GB") * 2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/cnvkit_batch.wdl
+++ b/definitions/tools/cnvkit_batch.wdl
@@ -21,6 +21,7 @@ task cnvkitBatch {
 
   Int size_needed_gb = 10 + round(size([tumor_bam, bait_intervals, access, normal_bam, reference_fasta, reference_cnn], "GB") * 2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cnvkit_vcf_export.wdl
+++ b/definitions/tools/cnvkit_vcf_export.wdl
@@ -11,7 +11,6 @@ task cnvkitVcfExport {
 
   Int space_needed_gb = 10 + round(2*size([cns_file, cnr_file], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/cnvkit_vcf_export.wdl
+++ b/definitions/tools/cnvkit_vcf_export.wdl
@@ -11,6 +11,8 @@ task cnvkitVcfExport {
 
   Int space_needed_gb = 10 + round(2*size([cns_file, cnr_file], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "8GB"
     docker: "mgibio/cnvkit:0.9.9"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/cnvkit_vcf_export.wdl
+++ b/definitions/tools/cnvkit_vcf_export.wdl
@@ -11,6 +11,7 @@ task cnvkitVcfExport {
 
   Int space_needed_gb = 10 + round(2*size([cns_file, cnr_file], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/cnvkit_vcf_export.wdl
+++ b/definitions/tools/cnvkit_vcf_export.wdl
@@ -11,7 +11,6 @@ task cnvkitVcfExport {
 
   Int space_needed_gb = 10 + round(2*size([cns_file, cnr_file], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cnvkit_vcf_export.wdl
+++ b/definitions/tools/cnvkit_vcf_export.wdl
@@ -11,6 +11,7 @@ task cnvkitVcfExport {
 
   Int space_needed_gb = 10 + round(2*size([cns_file, cnr_file], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cnvnator.wdl
+++ b/definitions/tools/cnvnator.wdl
@@ -11,7 +11,6 @@ task cnvnator {
   }
 
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cnvnator.wdl
+++ b/definitions/tools/cnvnator.wdl
@@ -11,6 +11,7 @@ task cnvnator {
   }
 
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/cnvnator-cwl:0.4"

--- a/definitions/tools/cnvnator.wdl
+++ b/definitions/tools/cnvnator.wdl
@@ -11,7 +11,6 @@ task cnvnator {
   }
 
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/cnvnator-cwl:0.4"

--- a/definitions/tools/cnvnator.wdl
+++ b/definitions/tools/cnvnator.wdl
@@ -11,6 +11,7 @@ task cnvnator {
   }
 
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/cnvnator.wdl
+++ b/definitions/tools/cnvnator.wdl
@@ -11,6 +11,8 @@ task cnvnator {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/cnvnator-cwl:0.4"
     memory: "20GB"
     bootDiskSizeGb: 10

--- a/definitions/tools/collect_alignment_summary_metrics.wdl
+++ b/definitions/tools/collect_alignment_summary_metrics.wdl
@@ -11,7 +11,9 @@ task collectAlignmentSummaryMetrics {
   }
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict],"GB"))
-  runtime{
+  runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "48GB"
     docker: "broadinstitute/picard:2.23.6"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/collect_gc_bias_metrics.wdl
+++ b/definitions/tools/collect_gc_bias_metrics.wdl
@@ -16,7 +16,6 @@ task collectGcBiasMetrics {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(bam_size_gb + reference_size_gb)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/collect_gc_bias_metrics.wdl
+++ b/definitions/tools/collect_gc_bias_metrics.wdl
@@ -16,7 +16,6 @@ task collectGcBiasMetrics {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(bam_size_gb + reference_size_gb)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "48GB"

--- a/definitions/tools/collect_gc_bias_metrics.wdl
+++ b/definitions/tools/collect_gc_bias_metrics.wdl
@@ -16,6 +16,7 @@ task collectGcBiasMetrics {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(bam_size_gb + reference_size_gb)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/collect_gc_bias_metrics.wdl
+++ b/definitions/tools/collect_gc_bias_metrics.wdl
@@ -16,6 +16,7 @@ task collectGcBiasMetrics {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(bam_size_gb + reference_size_gb)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "48GB"

--- a/definitions/tools/collect_gc_bias_metrics.wdl
+++ b/definitions/tools/collect_gc_bias_metrics.wdl
@@ -16,6 +16,8 @@ task collectGcBiasMetrics {
   Float reference_size_gb = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(bam_size_gb + reference_size_gb)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "48GB"
     docker: "broadinstitute/picard:2.23.6"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/collect_hs_metrics.wdl
+++ b/definitions/tools/collect_hs_metrics.wdl
@@ -20,7 +20,9 @@ task collectHsMetrics {
   }
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict, bait_intervals, target_intervals], "GB"))
-  runtime{
+  runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "60GB"
     docker: "broadinstitute/picard:2.23.6"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/collect_insert_size_metrics.wdl
+++ b/definitions/tools/collect_insert_size_metrics.wdl
@@ -12,6 +12,7 @@ task collectInsertSizeMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/collect_insert_size_metrics.wdl
+++ b/definitions/tools/collect_insert_size_metrics.wdl
@@ -12,6 +12,8 @@ task collectInsertSizeMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "broadinstitute/picard:2.23.6"
     memory: "48GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/collect_insert_size_metrics.wdl
+++ b/definitions/tools/collect_insert_size_metrics.wdl
@@ -12,6 +12,7 @@ task collectInsertSizeMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/picard:2.23.6"

--- a/definitions/tools/collect_insert_size_metrics.wdl
+++ b/definitions/tools/collect_insert_size_metrics.wdl
@@ -12,7 +12,6 @@ task collectInsertSizeMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/picard:2.23.6"

--- a/definitions/tools/collect_insert_size_metrics.wdl
+++ b/definitions/tools/collect_insert_size_metrics.wdl
@@ -12,7 +12,6 @@ task collectInsertSizeMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, reference, reference_fai, reference_dict], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/collect_wgs_metrics.wdl
+++ b/definitions/tools/collect_wgs_metrics.wdl
@@ -18,6 +18,7 @@ task collectWgsMetrics {
   Float intervals_size = size(intervals, "GB")
   Int space_needed_gb = 10 + round(bam_size + reference_size + intervals_size)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "48GB"

--- a/definitions/tools/collect_wgs_metrics.wdl
+++ b/definitions/tools/collect_wgs_metrics.wdl
@@ -18,6 +18,7 @@ task collectWgsMetrics {
   Float intervals_size = size(intervals, "GB")
   Int space_needed_gb = 10 + round(bam_size + reference_size + intervals_size)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/collect_wgs_metrics.wdl
+++ b/definitions/tools/collect_wgs_metrics.wdl
@@ -18,6 +18,8 @@ task collectWgsMetrics {
   Float intervals_size = size(intervals, "GB")
   Int space_needed_gb = 10 + round(bam_size + reference_size + intervals_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "48GB"
     docker: "broadinstitute/picard:2.23.6"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/collect_wgs_metrics.wdl
+++ b/definitions/tools/collect_wgs_metrics.wdl
@@ -18,7 +18,6 @@ task collectWgsMetrics {
   Float intervals_size = size(intervals, "GB")
   Int space_needed_gb = 10 + round(bam_size + reference_size + intervals_size)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/collect_wgs_metrics.wdl
+++ b/definitions/tools/collect_wgs_metrics.wdl
@@ -18,7 +18,6 @@ task collectWgsMetrics {
   Float intervals_size = size(intervals, "GB")
   Int space_needed_gb = 10 + round(bam_size + reference_size + intervals_size)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "48GB"

--- a/definitions/tools/combine_variants.wdl
+++ b/definitions/tools/combine_variants.wdl
@@ -19,7 +19,6 @@ task combineVariants {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/combine_variants.wdl
+++ b/definitions/tools/combine_variants.wdl
@@ -19,7 +19,6 @@ task combineVariants {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/combine_variants.wdl
+++ b/definitions/tools/combine_variants.wdl
@@ -19,6 +19,8 @@ task combineVariants {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     docker:  "mgibio/gatk-cwl:3.6.0"
     bootDiskSizeGb: 25

--- a/definitions/tools/combine_variants.wdl
+++ b/definitions/tools/combine_variants.wdl
@@ -19,6 +19,7 @@ task combineVariants {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/combine_variants.wdl
+++ b/definitions/tools/combine_variants.wdl
@@ -19,6 +19,7 @@ task combineVariants {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/combine_variants_wgs.wdl
+++ b/definitions/tools/combine_variants_wgs.wdl
@@ -19,6 +19,8 @@ task combineVariantsWgs {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     docker:  "mgibio/gatk-cwl:3.6.0"
     bootDiskSizeGb: 25

--- a/definitions/tools/combine_variants_wgs.wdl
+++ b/definitions/tools/combine_variants_wgs.wdl
@@ -19,7 +19,6 @@ task combineVariantsWgs {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/combine_variants_wgs.wdl
+++ b/definitions/tools/combine_variants_wgs.wdl
@@ -19,6 +19,7 @@ task combineVariantsWgs {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/combine_variants_wgs.wdl
+++ b/definitions/tools/combine_variants_wgs.wdl
@@ -19,7 +19,6 @@ task combineVariantsWgs {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/combine_variants_wgs.wdl
+++ b/definitions/tools/combine_variants_wgs.wdl
@@ -19,6 +19,7 @@ task combineVariantsWgs {
   Float strelka_size = size([strelka_vcf, strelka_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(ref_size + mutect_size + varscan_size + strelka_size)*2
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/concordance.wdl
+++ b/definitions/tools/concordance.wdl
@@ -18,7 +18,6 @@ task concordance {
 
   Int space_needed_gb = 10 + round(size([vcf, reference, reference_fai, reference_dict, bam_1, bam_1_bai, bam_2, bam_2_bai, bam_3, bam_3_bai], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     cpu: 1

--- a/definitions/tools/concordance.wdl
+++ b/definitions/tools/concordance.wdl
@@ -18,6 +18,7 @@ task concordance {
 
   Int space_needed_gb = 10 + round(size([vcf, reference, reference_fai, reference_dict, bam_1, bam_1_bai, bam_2, bam_2_bai, bam_3, bam_3_bai], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     cpu: 1

--- a/definitions/tools/concordance.wdl
+++ b/definitions/tools/concordance.wdl
@@ -18,6 +18,7 @@ task concordance {
 
   Int space_needed_gb = 10 + round(size([vcf, reference, reference_fai, reference_dict, bam_1, bam_1_bai, bam_2, bam_2_bai, bam_3, bam_3_bai], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/concordance.wdl
+++ b/definitions/tools/concordance.wdl
@@ -18,7 +18,6 @@ task concordance {
 
   Int space_needed_gb = 10 + round(size([vcf, reference, reference_fai, reference_dict, bam_1, bam_1_bai, bam_2, bam_2_bai, bam_3, bam_3_bai], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/concordance.wdl
+++ b/definitions/tools/concordance.wdl
@@ -18,6 +18,8 @@ task concordance {
 
   Int space_needed_gb = 10 + round(size([vcf, reference, reference_fai, reference_dict, bam_1, bam_1_bai, bam_2, bam_2_bai, bam_3, bam_3_bai], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     cpu: 1
     memory: "8GB"
     bootDiskSizeGb: 10

--- a/definitions/tools/docm_add_variants.wdl
+++ b/definitions/tools/docm_add_variants.wdl
@@ -15,6 +15,7 @@ task docmAddVariants {
   Float docm_size = size([docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + callers_size + docm_size)*2
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/docm_add_variants.wdl
+++ b/definitions/tools/docm_add_variants.wdl
@@ -15,6 +15,8 @@ task docmAddVariants {
   Float docm_size = size([docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + callers_size + docm_size)*2
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     bootDiskSizeGb: 25
     docker: "mgibio/gatk-cwl:3.6.0"

--- a/definitions/tools/docm_add_variants.wdl
+++ b/definitions/tools/docm_add_variants.wdl
@@ -15,7 +15,6 @@ task docmAddVariants {
   Float docm_size = size([docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + callers_size + docm_size)*2
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/docm_add_variants.wdl
+++ b/definitions/tools/docm_add_variants.wdl
@@ -15,6 +15,7 @@ task docmAddVariants {
   Float docm_size = size([docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + callers_size + docm_size)*2
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/docm_add_variants.wdl
+++ b/definitions/tools/docm_add_variants.wdl
@@ -15,7 +15,6 @@ task docmAddVariants {
   Float docm_size = size([docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + callers_size + docm_size)*2
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/docm_gatk_haplotype_caller.wdl
+++ b/definitions/tools/docm_gatk_haplotype_caller.wdl
@@ -24,6 +24,7 @@ task docmGatkHaplotypeCaller {
   Float copied_size = size([docm_vcf, interval_list], "GB")
   Int space_needed_gb = 10 + round(copied_size*3 + size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, bam, bam_bai, docm_vcf_tbi], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/docm_gatk_haplotype_caller.wdl
+++ b/definitions/tools/docm_gatk_haplotype_caller.wdl
@@ -24,7 +24,6 @@ task docmGatkHaplotypeCaller {
   Float copied_size = size([docm_vcf, interval_list], "GB")
   Int space_needed_gb = 10 + round(copied_size*3 + size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, bam, bam_bai, docm_vcf_tbi], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/docm_gatk_haplotype_caller.wdl
+++ b/definitions/tools/docm_gatk_haplotype_caller.wdl
@@ -24,7 +24,6 @@ task docmGatkHaplotypeCaller {
   Float copied_size = size([docm_vcf, interval_list], "GB")
   Int space_needed_gb = 10 + round(copied_size*3 + size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, bam, bam_bai, docm_vcf_tbi], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/docm_gatk_haplotype_caller.wdl
+++ b/definitions/tools/docm_gatk_haplotype_caller.wdl
@@ -24,6 +24,8 @@ task docmGatkHaplotypeCaller {
   Float copied_size = size([docm_vcf, interval_list], "GB")
   Int space_needed_gb = 10 + round(copied_size*3 + size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, bam, bam_bai, docm_vcf_tbi], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     docker: "broadinstitute/gatk:4.1.2.0"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/docm_gatk_haplotype_caller.wdl
+++ b/definitions/tools/docm_gatk_haplotype_caller.wdl
@@ -24,6 +24,7 @@ task docmGatkHaplotypeCaller {
   Float copied_size = size([docm_vcf, interval_list], "GB")
   Int space_needed_gb = 10 + round(copied_size*3 + size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, bam, bam_bai, docm_vcf_tbi], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/downsample.wdl
+++ b/definitions/tools/downsample.wdl
@@ -18,6 +18,7 @@ task downsample {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + size(sam, "GB") * 2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/downsample.wdl
+++ b/definitions/tools/downsample.wdl
@@ -18,7 +18,6 @@ task downsample {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + size(sam, "GB") * 2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/downsample.wdl
+++ b/definitions/tools/downsample.wdl
@@ -18,7 +18,6 @@ task downsample {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + size(sam, "GB") * 2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "18GB"

--- a/definitions/tools/downsample.wdl
+++ b/definitions/tools/downsample.wdl
@@ -18,6 +18,8 @@ task downsample {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + size(sam, "GB") * 2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "18GB"
     docker: "broadinstitute/gatk:4.1.4.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/downsample.wdl
+++ b/definitions/tools/downsample.wdl
@@ -18,6 +18,7 @@ task downsample {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + size(sam, "GB") * 2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "18GB"

--- a/definitions/tools/duphold.wdl
+++ b/definitions/tools/duphold.wdl
@@ -14,7 +14,6 @@ task duphold {
   Int cores = 2
   Int space_needed_gb = 10
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/duphold.wdl
+++ b/definitions/tools/duphold.wdl
@@ -14,6 +14,8 @@ task duphold {
   Int cores = 2
   Int space_needed_gb = 10
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "10GB"
     docker: "mgibio/duphold-cwl:0.1.5"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/duphold.wdl
+++ b/definitions/tools/duphold.wdl
@@ -14,6 +14,7 @@ task duphold {
   Int cores = 2
   Int space_needed_gb = 10
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "10GB"

--- a/definitions/tools/duphold.wdl
+++ b/definitions/tools/duphold.wdl
@@ -14,7 +14,6 @@ task duphold {
   Int cores = 2
   Int space_needed_gb = 10
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "10GB"

--- a/definitions/tools/duphold.wdl
+++ b/definitions/tools/duphold.wdl
@@ -14,6 +14,7 @@ task duphold {
   Int cores = 2
   Int space_needed_gb = 10
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/echo_file.wdl
+++ b/definitions/tools/echo_file.wdl
@@ -4,6 +4,7 @@ task echoFile {
   input {}
 
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/echo_file.wdl
+++ b/definitions/tools/echo_file.wdl
@@ -4,6 +4,7 @@ task echoFile {
   input {}
 
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:bionic"

--- a/definitions/tools/echo_file.wdl
+++ b/definitions/tools/echo_file.wdl
@@ -4,7 +4,6 @@ task echoFile {
   input {}
 
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/echo_file.wdl
+++ b/definitions/tools/echo_file.wdl
@@ -4,7 +4,6 @@ task echoFile {
   input {}
 
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:bionic"

--- a/definitions/tools/echo_file.wdl
+++ b/definitions/tools/echo_file.wdl
@@ -4,6 +4,8 @@ task echoFile {
   input {}
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "ubuntu:bionic"
   }
 

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -8,6 +8,7 @@ task extractHlaAlleles {
 
   Int space_needed_gb = 10 + round(size(file, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -8,7 +8,6 @@ task extractHlaAlleles {
 
   Int space_needed_gb = 10 + round(size(file, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "2GB"

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -8,6 +8,8 @@ task extractHlaAlleles {
 
   Int space_needed_gb = 10 + round(size(file, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "2GB"
     docker: "ubuntu:xenial"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -8,7 +8,6 @@ task extractHlaAlleles {
 
   Int space_needed_gb = 10 + round(size(file, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/extract_hla_alleles.wdl
+++ b/definitions/tools/extract_hla_alleles.wdl
@@ -8,6 +8,7 @@ task extractHlaAlleles {
 
   Int space_needed_gb = 10 + round(size(file, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "2GB"

--- a/definitions/tools/filter_known_variants.wdl
+++ b/definitions/tools/filter_known_variants.wdl
@@ -10,7 +10,6 @@ task filterKnownVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_known_variants.wdl
+++ b/definitions/tools/filter_known_variants.wdl
@@ -10,6 +10,8 @@ task filterKnownVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/bcftools-cwl:1.12"
     memory: "8GB"
     disks:  "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_known_variants.wdl
+++ b/definitions/tools/filter_known_variants.wdl
@@ -10,6 +10,7 @@ task filterKnownVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_known_variants.wdl
+++ b/definitions/tools/filter_known_variants.wdl
@@ -10,6 +10,7 @@ task filterKnownVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bcftools-cwl:1.12"

--- a/definitions/tools/filter_known_variants.wdl
+++ b/definitions/tools/filter_known_variants.wdl
@@ -10,7 +10,6 @@ task filterKnownVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bcftools-cwl:1.12"

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
@@ -10,6 +10,7 @@ task filterSvVcfBlocklistBedpe {
 
   Int space_needed_gb = 10
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
@@ -10,7 +10,6 @@ task filterSvVcfBlocklistBedpe {
 
   Int space_needed_gb = 10
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
@@ -10,7 +10,6 @@ task filterSvVcfBlocklistBedpe {
 
   Int space_needed_gb = 10
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
@@ -10,6 +10,8 @@ task filterSvVcfBlocklistBedpe {
 
   Int space_needed_gb = 10
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "8GB"
     docker: "mgibio/basespace_chromoseq:v12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.wdl
@@ -10,6 +10,7 @@ task filterSvVcfBlocklistBedpe {
 
   Int space_needed_gb = 10
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/filter_sv_vcf_depth.wdl
+++ b/definitions/tools/filter_sv_vcf_depth.wdl
@@ -11,7 +11,6 @@ task filterSvVcfDepth {
 
   Int space_needed_gb = 10 + round(2*size(input_vcf, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_depth.wdl
+++ b/definitions/tools/filter_sv_vcf_depth.wdl
@@ -11,6 +11,8 @@ task filterSvVcfDepth {
 
   Int space_needed_gb = 10 + round(2*size(input_vcf, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibiobcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_sv_vcf_depth.wdl
+++ b/definitions/tools/filter_sv_vcf_depth.wdl
@@ -11,6 +11,7 @@ task filterSvVcfDepth {
 
   Int space_needed_gb = 10 + round(2*size(input_vcf, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_sv_vcf_depth.wdl
+++ b/definitions/tools/filter_sv_vcf_depth.wdl
@@ -11,6 +11,7 @@ task filterSvVcfDepth {
 
   Int space_needed_gb = 10 + round(2*size(input_vcf, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_depth.wdl
+++ b/definitions/tools/filter_sv_vcf_depth.wdl
@@ -11,7 +11,6 @@ task filterSvVcfDepth {
 
   Int space_needed_gb = 10 + round(2*size(input_vcf, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_sv_vcf_read_support.wdl
+++ b/definitions/tools/filter_sv_vcf_read_support.wdl
@@ -12,7 +12,6 @@ task filterSvVcfReadSupport {
 
   Int space_needed_gb = 10
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_read_support.wdl
+++ b/definitions/tools/filter_sv_vcf_read_support.wdl
@@ -12,6 +12,7 @@ task filterSvVcfReadSupport {
 
   Int space_needed_gb = 10
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_sv_vcf_read_support.wdl
+++ b/definitions/tools/filter_sv_vcf_read_support.wdl
@@ -12,6 +12,7 @@ task filterSvVcfReadSupport {
 
   Int space_needed_gb = 10
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_read_support.wdl
+++ b/definitions/tools/filter_sv_vcf_read_support.wdl
@@ -12,6 +12,8 @@ task filterSvVcfReadSupport {
 
   Int space_needed_gb = 10
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "bcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_sv_vcf_read_support.wdl
+++ b/definitions/tools/filter_sv_vcf_read_support.wdl
@@ -12,7 +12,6 @@ task filterSvVcfReadSupport {
 
   Int space_needed_gb = 10
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_sv_vcf_size.wdl
+++ b/definitions/tools/filter_sv_vcf_size.wdl
@@ -10,7 +10,6 @@ task filterSvVcfSize {
 
   Int space_needed_gb = 10
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_size.wdl
+++ b/definitions/tools/filter_sv_vcf_size.wdl
@@ -10,6 +10,8 @@ task filterSvVcfSize {
 
   Int space_needed_gb = 10
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibio/bcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_sv_vcf_size.wdl
+++ b/definitions/tools/filter_sv_vcf_size.wdl
@@ -10,6 +10,7 @@ task filterSvVcfSize {
 
   Int space_needed_gb = 10
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_sv_vcf_size.wdl
+++ b/definitions/tools/filter_sv_vcf_size.wdl
@@ -10,7 +10,6 @@ task filterSvVcfSize {
 
   Int space_needed_gb = 10
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_sv_vcf_size.wdl
+++ b/definitions/tools/filter_sv_vcf_size.wdl
@@ -10,6 +10,7 @@ task filterSvVcfSize {
 
   Int space_needed_gb = 10
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_vcf_cle.wdl
+++ b/definitions/tools/filter_vcf_cle.wdl
@@ -8,7 +8,6 @@ task filterVcfCle {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/cle:v1.3.1"

--- a/definitions/tools/filter_vcf_cle.wdl
+++ b/definitions/tools/filter_vcf_cle.wdl
@@ -8,6 +8,7 @@ task filterVcfCle {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/cle:v1.3.1"

--- a/definitions/tools/filter_vcf_cle.wdl
+++ b/definitions/tools/filter_vcf_cle.wdl
@@ -8,7 +8,6 @@ task filterVcfCle {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_cle.wdl
+++ b/definitions/tools/filter_vcf_cle.wdl
@@ -8,6 +8,7 @@ task filterVcfCle {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_cle.wdl
+++ b/definitions/tools/filter_vcf_cle.wdl
@@ -8,6 +8,8 @@ task filterVcfCle {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/cle:v1.3.1"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_vcf_coding_variant.wdl
+++ b/definitions/tools/filter_vcf_coding_variant.wdl
@@ -7,6 +7,7 @@ task filterVcfCodingVariant {
 
   Int space_needed_gb = 10 + round(2*size(vcf, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_vcf_coding_variant.wdl
+++ b/definitions/tools/filter_vcf_coding_variant.wdl
@@ -7,7 +7,6 @@ task filterVcfCodingVariant {
 
   Int space_needed_gb = 10 + round(2*size(vcf, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_coding_variant.wdl
+++ b/definitions/tools/filter_vcf_coding_variant.wdl
@@ -7,6 +7,8 @@ task filterVcfCodingVariant {
 
   Int space_needed_gb = 10 + round(2*size(vcf, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibio/vep_helper-cwl:vep_105.0_v1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_vcf_coding_variant.wdl
+++ b/definitions/tools/filter_vcf_coding_variant.wdl
@@ -7,6 +7,7 @@ task filterVcfCodingVariant {
 
   Int space_needed_gb = 10 + round(2*size(vcf, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_coding_variant.wdl
+++ b/definitions/tools/filter_vcf_coding_variant.wdl
@@ -7,7 +7,6 @@ task filterVcfCodingVariant {
 
   Int space_needed_gb = 10 + round(2*size(vcf, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/filter_vcf_custom_allele_freq.wdl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.wdl
@@ -9,6 +9,7 @@ task filterVcfCustomAlleleFreq {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_custom_allele_freq.wdl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.wdl
@@ -9,6 +9,7 @@ task filterVcfCustomAlleleFreq {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/vep_helper-cwl:vep_105.0_v1"

--- a/definitions/tools/filter_vcf_custom_allele_freq.wdl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.wdl
@@ -9,6 +9,8 @@ task filterVcfCustomAlleleFreq {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/vep_helper-cwl:vep_105.0_v1"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_vcf_custom_allele_freq.wdl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.wdl
@@ -9,7 +9,6 @@ task filterVcfCustomAlleleFreq {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/vep_helper-cwl:vep_105.0_v1"

--- a/definitions/tools/filter_vcf_custom_allele_freq.wdl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.wdl
@@ -9,7 +9,6 @@ task filterVcfCustomAlleleFreq {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_depth.wdl
+++ b/definitions/tools/filter_vcf_depth.wdl
@@ -9,7 +9,6 @@ task filterVcfDepth {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/depth-filter:0.1.2"

--- a/definitions/tools/filter_vcf_depth.wdl
+++ b/definitions/tools/filter_vcf_depth.wdl
@@ -9,7 +9,6 @@ task filterVcfDepth {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_depth.wdl
+++ b/definitions/tools/filter_vcf_depth.wdl
@@ -9,6 +9,7 @@ task filterVcfDepth {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_depth.wdl
+++ b/definitions/tools/filter_vcf_depth.wdl
@@ -9,6 +9,7 @@ task filterVcfDepth {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/depth-filter:0.1.2"

--- a/definitions/tools/filter_vcf_depth.wdl
+++ b/definitions/tools/filter_vcf_depth.wdl
@@ -9,6 +9,8 @@ task filterVcfDepth {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/depth-filter:0.1.2"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_vcf_docm.wdl
+++ b/definitions/tools/filter_vcf_docm.wdl
@@ -10,7 +10,6 @@ task filterVcfDocm {
 
   Int space_needed_gb = 10 + round(size(docm_raw_variants, "GB")*2 + size([normal_bam, tumor_bam], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/cle:v1.4.2"

--- a/definitions/tools/filter_vcf_docm.wdl
+++ b/definitions/tools/filter_vcf_docm.wdl
@@ -10,7 +10,6 @@ task filterVcfDocm {
 
   Int space_needed_gb = 10 + round(size(docm_raw_variants, "GB")*2 + size([normal_bam, tumor_bam], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_docm.wdl
+++ b/definitions/tools/filter_vcf_docm.wdl
@@ -10,6 +10,7 @@ task filterVcfDocm {
 
   Int space_needed_gb = 10 + round(size(docm_raw_variants, "GB")*2 + size([normal_bam, tumor_bam], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_docm.wdl
+++ b/definitions/tools/filter_vcf_docm.wdl
@@ -10,6 +10,8 @@ task filterVcfDocm {
 
   Int space_needed_gb = 10 + round(size(docm_raw_variants, "GB")*2 + size([normal_bam, tumor_bam], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/cle:v1.4.2"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_vcf_docm.wdl
+++ b/definitions/tools/filter_vcf_docm.wdl
@@ -10,6 +10,7 @@ task filterVcfDocm {
 
   Int space_needed_gb = 10 + round(size(docm_raw_variants, "GB")*2 + size([normal_bam, tumor_bam], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/cle:v1.4.2"

--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -12,6 +12,8 @@ task filterVcfMapq0 {
   Float bam_size = size([tumor_bam, tumor_bam_bai], "GB")
   Int space_needed_gb = 10 + round(bam_size + 2*size(vcf, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/mapq0-filter:v0.5.3"
     memory: "8GB"
     bootDiskSizeGb: 10

--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -12,6 +12,7 @@ task filterVcfMapq0 {
   Float bam_size = size([tumor_bam, tumor_bam_bai], "GB")
   Int space_needed_gb = 10 + round(bam_size + 2*size(vcf, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -12,6 +12,7 @@ task filterVcfMapq0 {
   Float bam_size = size([tumor_bam, tumor_bam_bai], "GB")
   Int space_needed_gb = 10 + round(bam_size + 2*size(vcf, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/mapq0-filter:v0.5.3"

--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -12,7 +12,6 @@ task filterVcfMapq0 {
   Float bam_size = size([tumor_bam, tumor_bam_bai], "GB")
   Int space_needed_gb = 10 + round(bam_size + 2*size(vcf, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/mapq0-filter:v0.5.3"

--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -12,7 +12,6 @@ task filterVcfMapq0 {
   Float bam_size = size([tumor_bam, tumor_bam_bai], "GB")
   Int space_needed_gb = 10 + round(bam_size + 2*size(vcf, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_somatic_llr.wdl
+++ b/definitions/tools/filter_vcf_somatic_llr.wdl
@@ -12,6 +12,8 @@ task filterVcfSomaticLlr {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/somatic-llr-filter:v0.4.3"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/filter_vcf_somatic_llr.wdl
+++ b/definitions/tools/filter_vcf_somatic_llr.wdl
@@ -12,6 +12,7 @@ task filterVcfSomaticLlr {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/filter_vcf_somatic_llr.wdl
+++ b/definitions/tools/filter_vcf_somatic_llr.wdl
@@ -12,7 +12,6 @@ task filterVcfSomaticLlr {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/somatic-llr-filter:v0.4.3"

--- a/definitions/tools/filter_vcf_somatic_llr.wdl
+++ b/definitions/tools/filter_vcf_somatic_llr.wdl
@@ -12,6 +12,7 @@ task filterVcfSomaticLlr {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/somatic-llr-filter:v0.4.3"

--- a/definitions/tools/filter_vcf_somatic_llr.wdl
+++ b/definitions/tools/filter_vcf_somatic_llr.wdl
@@ -12,7 +12,6 @@ task filterVcfSomaticLlr {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/fp_filter.wdl
+++ b/definitions/tools/fp_filter.wdl
@@ -16,6 +16,8 @@ task fpFilter {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size([reference, reference_fai, reference_dict, bam], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "6GB"
     bootDiskSizeGb: 25
     docker: "mgibio/fp_filter-cwl:1.0.1"

--- a/definitions/tools/fp_filter.wdl
+++ b/definitions/tools/fp_filter.wdl
@@ -16,6 +16,7 @@ task fpFilter {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size([reference, reference_fai, reference_dict, bam], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "6GB"

--- a/definitions/tools/fp_filter.wdl
+++ b/definitions/tools/fp_filter.wdl
@@ -16,7 +16,6 @@ task fpFilter {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size([reference, reference_fai, reference_dict, bam], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "6GB"

--- a/definitions/tools/fp_filter.wdl
+++ b/definitions/tools/fp_filter.wdl
@@ -16,6 +16,7 @@ task fpFilter {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size([reference, reference_fai, reference_dict, bam], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/fp_filter.wdl
+++ b/definitions/tools/fp_filter.wdl
@@ -16,7 +16,6 @@ task fpFilter {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size([reference, reference_fai, reference_dict, bam], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/freemix.wdl
+++ b/definitions/tools/freemix.wdl
@@ -6,7 +6,6 @@ task freemix {
   }
 
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "python:3.10"

--- a/definitions/tools/freemix.wdl
+++ b/definitions/tools/freemix.wdl
@@ -6,7 +6,6 @@ task freemix {
   }
 
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/freemix.wdl
+++ b/definitions/tools/freemix.wdl
@@ -6,6 +6,7 @@ task freemix {
   }
 
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "python:3.10"

--- a/definitions/tools/freemix.wdl
+++ b/definitions/tools/freemix.wdl
@@ -6,6 +6,7 @@ task freemix {
   }
 
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/freemix.wdl
+++ b/definitions/tools/freemix.wdl
@@ -6,6 +6,8 @@ task freemix {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "python:3.10"
   }
 

--- a/definitions/tools/gatk_haplotype_caller.wdl
+++ b/definitions/tools/gatk_haplotype_caller.wdl
@@ -24,7 +24,6 @@ task gatkHaplotypeCaller {
   Float vcf_size = size([dbsnp_vcf, dbsnp_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*bam_size + vcf_size)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "18GB"

--- a/definitions/tools/gatk_haplotype_caller.wdl
+++ b/definitions/tools/gatk_haplotype_caller.wdl
@@ -24,7 +24,6 @@ task gatkHaplotypeCaller {
   Float vcf_size = size([dbsnp_vcf, dbsnp_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*bam_size + vcf_size)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/gatk_haplotype_caller.wdl
+++ b/definitions/tools/gatk_haplotype_caller.wdl
@@ -24,6 +24,8 @@ task gatkHaplotypeCaller {
   Float vcf_size = size([dbsnp_vcf, dbsnp_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*bam_size + vcf_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "18GB"
     docker: "broadinstitute/gatk:4.1.8.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/gatk_haplotype_caller.wdl
+++ b/definitions/tools/gatk_haplotype_caller.wdl
@@ -24,6 +24,7 @@ task gatkHaplotypeCaller {
   Float vcf_size = size([dbsnp_vcf, dbsnp_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*bam_size + vcf_size)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "18GB"

--- a/definitions/tools/gatk_haplotype_caller.wdl
+++ b/definitions/tools/gatk_haplotype_caller.wdl
@@ -24,6 +24,7 @@ task gatkHaplotypeCaller {
   Float vcf_size = size([dbsnp_vcf, dbsnp_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*bam_size + vcf_size)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/generate_qc_metrics.wdl
+++ b/definitions/tools/generate_qc_metrics.wdl
@@ -10,7 +10,6 @@ task generateQcMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, refFlat, ribosomal_intervals], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/generate_qc_metrics.wdl
+++ b/definitions/tools/generate_qc_metrics.wdl
@@ -10,6 +10,7 @@ task generateQcMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, refFlat, ribosomal_intervals], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "18GB"

--- a/definitions/tools/generate_qc_metrics.wdl
+++ b/definitions/tools/generate_qc_metrics.wdl
@@ -10,6 +10,8 @@ task generateQcMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, refFlat, ribosomal_intervals], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "18GB"
     docker: "mgibio/rnaseq:1.0.0"
     cpu: 1

--- a/definitions/tools/generate_qc_metrics.wdl
+++ b/definitions/tools/generate_qc_metrics.wdl
@@ -10,7 +10,6 @@ task generateQcMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, refFlat, ribosomal_intervals], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "18GB"

--- a/definitions/tools/generate_qc_metrics.wdl
+++ b/definitions/tools/generate_qc_metrics.wdl
@@ -10,6 +10,7 @@ task generateQcMetrics {
 
   Int space_needed_gb = 10 + round(size([bam, refFlat, ribosomal_intervals], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/germline_combine_variants.wdl
+++ b/definitions/tools/germline_combine_variants.wdl
@@ -15,7 +15,6 @@ task germlineCombineVariants {
   Float vcf_size = size([varscan_vcf, varscan_vcf_tbi, docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*vcf_size)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/germline_combine_variants.wdl
+++ b/definitions/tools/germline_combine_variants.wdl
@@ -15,7 +15,6 @@ task germlineCombineVariants {
   Float vcf_size = size([varscan_vcf, varscan_vcf_tbi, docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*vcf_size)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/germline_combine_variants.wdl
+++ b/definitions/tools/germline_combine_variants.wdl
@@ -15,6 +15,7 @@ task germlineCombineVariants {
   Float vcf_size = size([varscan_vcf, varscan_vcf_tbi, docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*vcf_size)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/germline_combine_variants.wdl
+++ b/definitions/tools/germline_combine_variants.wdl
@@ -15,6 +15,7 @@ task germlineCombineVariants {
   Float vcf_size = size([varscan_vcf, varscan_vcf_tbi, docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*vcf_size)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/germline_combine_variants.wdl
+++ b/definitions/tools/germline_combine_variants.wdl
@@ -15,6 +15,8 @@ task germlineCombineVariants {
   Float vcf_size = size([varscan_vcf, varscan_vcf_tbi, docm_vcf, docm_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*vcf_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     bootDiskSizeGb: 25
     docker: "mgibio/gatk-cwl:3.6.0"

--- a/definitions/tools/hisat2_align.wdl
+++ b/definitions/tools/hisat2_align.wdl
@@ -33,7 +33,6 @@ task hisat2Align {
   ], "GB")
   Int space_needed_gb = 10 + round(5*fastq_size_gb + reference_size_gb)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/hisat2_align.wdl
+++ b/definitions/tools/hisat2_align.wdl
@@ -33,7 +33,6 @@ task hisat2Align {
   ], "GB")
   Int space_needed_gb = 10 + round(5*fastq_size_gb + reference_size_gb)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/hisat2_align.wdl
+++ b/definitions/tools/hisat2_align.wdl
@@ -33,6 +33,7 @@ task hisat2Align {
   ], "GB")
   Int space_needed_gb = 10 + round(5*fastq_size_gb + reference_size_gb)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/hisat2_align.wdl
+++ b/definitions/tools/hisat2_align.wdl
@@ -33,6 +33,7 @@ task hisat2Align {
   ], "GB")
   Int space_needed_gb = 10 + round(5*fastq_size_gb + reference_size_gb)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/hisat2_align.wdl
+++ b/definitions/tools/hisat2_align.wdl
@@ -33,6 +33,8 @@ task hisat2Align {
   ], "GB")
   Int space_needed_gb = 10 + round(5*fastq_size_gb + reference_size_gb)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "32GB"
     cpu: cores
     bootDiskSizeGb: space_needed_gb

--- a/definitions/tools/hla_consensus.wdl
+++ b/definitions/tools/hla_consensus.wdl
@@ -9,6 +9,7 @@ task hlaConsensus {
   }
 
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "python:3.7.4-slim-buster"

--- a/definitions/tools/hla_consensus.wdl
+++ b/definitions/tools/hla_consensus.wdl
@@ -9,7 +9,6 @@ task hlaConsensus {
   }
 
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/hla_consensus.wdl
+++ b/definitions/tools/hla_consensus.wdl
@@ -9,6 +9,8 @@ task hlaConsensus {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "python:3.7.4-slim-buster"
     memory: "4GB"
   }

--- a/definitions/tools/hla_consensus.wdl
+++ b/definitions/tools/hla_consensus.wdl
@@ -9,7 +9,6 @@ task hlaConsensus {
   }
 
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "python:3.7.4-slim-buster"

--- a/definitions/tools/hla_consensus.wdl
+++ b/definitions/tools/hla_consensus.wdl
@@ -9,6 +9,7 @@ task hlaConsensus {
   }
 
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_bam.wdl
+++ b/definitions/tools/index_bam.wdl
@@ -5,6 +5,7 @@ task indexBam {
 
   Int space_needed_gb = 10 + round(size(bam, "GB")*3)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_bam.wdl
+++ b/definitions/tools/index_bam.wdl
@@ -5,6 +5,8 @@ task indexBam {
 
   Int space_needed_gb = 10 + round(size(bam, "GB")*3)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/index_bam.wdl
+++ b/definitions/tools/index_bam.wdl
@@ -5,7 +5,6 @@ task indexBam {
 
   Int space_needed_gb = 10 + round(size(bam, "GB")*3)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_bam.wdl
+++ b/definitions/tools/index_bam.wdl
@@ -5,7 +5,6 @@ task indexBam {
 
   Int space_needed_gb = 10 + round(size(bam, "GB")*3)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/index_bam.wdl
+++ b/definitions/tools/index_bam.wdl
@@ -5,6 +5,7 @@ task indexBam {
 
   Int space_needed_gb = 10 + round(size(bam, "GB")*3)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/index_cram.wdl
+++ b/definitions/tools/index_cram.wdl
@@ -5,6 +5,7 @@ task indexCram {
 
   Int space_needed_gb = 10 + round(size(cram, "GB")*3)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_cram.wdl
+++ b/definitions/tools/index_cram.wdl
@@ -5,7 +5,6 @@ task indexCram {
 
   Int space_needed_gb = 10 + round(size(cram, "GB")*3)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_cram.wdl
+++ b/definitions/tools/index_cram.wdl
@@ -5,7 +5,6 @@ task indexCram {
 
   Int space_needed_gb = 10 + round(size(cram, "GB")*3)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/index_cram.wdl
+++ b/definitions/tools/index_cram.wdl
@@ -5,6 +5,8 @@ task indexCram {
 
   Int space_needed_gb = 10 + round(size(cram, "GB")*3)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/index_cram.wdl
+++ b/definitions/tools/index_cram.wdl
@@ -5,6 +5,7 @@ task indexCram {
 
   Int space_needed_gb = 10 + round(size(cram, "GB")*3)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/index_vcf.wdl
+++ b/definitions/tools/index_vcf.wdl
@@ -7,6 +7,8 @@ task indexVcf {
 
   Int space_needed_gb = 10 + round(3*size(vcf, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/index_vcf.wdl
+++ b/definitions/tools/index_vcf.wdl
@@ -7,6 +7,7 @@ task indexVcf {
 
   Int space_needed_gb = 10 + round(3*size(vcf, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/index_vcf.wdl
+++ b/definitions/tools/index_vcf.wdl
@@ -7,7 +7,6 @@ task indexVcf {
 
   Int space_needed_gb = 10 + round(3*size(vcf, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_vcf.wdl
+++ b/definitions/tools/index_vcf.wdl
@@ -7,6 +7,7 @@ task indexVcf {
 
   Int space_needed_gb = 10 + round(3*size(vcf, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/index_vcf.wdl
+++ b/definitions/tools/index_vcf.wdl
@@ -7,7 +7,6 @@ task indexVcf {
 
   Int space_needed_gb = 10 + round(3*size(vcf, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/intersect_known_variants.wdl
+++ b/definitions/tools/intersect_known_variants.wdl
@@ -10,6 +10,8 @@ task intersectKnownVariants {
 
   Int space_needed_gb = 10 + round(2*size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "8GB"
     docker: "mgibio/bcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/intersect_known_variants.wdl
+++ b/definitions/tools/intersect_known_variants.wdl
@@ -10,6 +10,7 @@ task intersectKnownVariants {
 
   Int space_needed_gb = 10 + round(2*size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/intersect_known_variants.wdl
+++ b/definitions/tools/intersect_known_variants.wdl
@@ -10,6 +10,7 @@ task intersectKnownVariants {
 
   Int space_needed_gb = 10 + round(2*size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/intersect_known_variants.wdl
+++ b/definitions/tools/intersect_known_variants.wdl
@@ -10,7 +10,6 @@ task intersectKnownVariants {
 
   Int space_needed_gb = 10 + round(2*size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "8GB"

--- a/definitions/tools/intersect_known_variants.wdl
+++ b/definitions/tools/intersect_known_variants.wdl
@@ -10,7 +10,6 @@ task intersectKnownVariants {
 
   Int space_needed_gb = 10 + round(2*size([vcf, vcf_tbi, validated_variants, validated_variants_tbi], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/interval_list_expand.wdl
+++ b/definitions/tools/interval_list_expand.wdl
@@ -8,7 +8,6 @@ task intervalListExpand {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/interval_list_expand.wdl
+++ b/definitions/tools/interval_list_expand.wdl
@@ -8,7 +8,6 @@ task intervalListExpand {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/interval_list_expand.wdl
+++ b/definitions/tools/interval_list_expand.wdl
@@ -8,6 +8,7 @@ task intervalListExpand {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/interval_list_expand.wdl
+++ b/definitions/tools/interval_list_expand.wdl
@@ -8,6 +8,7 @@ task intervalListExpand {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "4GB"

--- a/definitions/tools/interval_list_expand.wdl
+++ b/definitions/tools/interval_list_expand.wdl
@@ -8,6 +8,8 @@ task intervalListExpand {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "broadinstitute/picard:2.23.6"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/intervals_to_bed.wdl
+++ b/definitions/tools/intervals_to_bed.wdl
@@ -6,7 +6,6 @@ task intervalsToBed {
   }
 
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/intervals_to_bed.wdl
+++ b/definitions/tools/intervals_to_bed.wdl
@@ -6,7 +6,6 @@ task intervalsToBed {
   }
 
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:bionic"

--- a/definitions/tools/intervals_to_bed.wdl
+++ b/definitions/tools/intervals_to_bed.wdl
@@ -6,6 +6,8 @@ task intervalsToBed {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "ubuntu:bionic"
     memory: "4GB"
   }

--- a/definitions/tools/intervals_to_bed.wdl
+++ b/definitions/tools/intervals_to_bed.wdl
@@ -6,6 +6,7 @@ task intervalsToBed {
   }
 
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "ubuntu:bionic"

--- a/definitions/tools/intervals_to_bed.wdl
+++ b/definitions/tools/intervals_to_bed.wdl
@@ -6,6 +6,7 @@ task intervalsToBed {
   }
 
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/kallisto.wdl
+++ b/definitions/tools/kallisto.wdl
@@ -10,6 +10,7 @@ task kallisto {
   Int cores = 8
   Int space_needed_gb = 10 + round(size(flatten(fastqs), "GB") + size(kallisto_index, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/kallisto.wdl
+++ b/definitions/tools/kallisto.wdl
@@ -10,7 +10,6 @@ task kallisto {
   Int cores = 8
   Int space_needed_gb = 10 + round(size(flatten(fastqs), "GB") + size(kallisto_index, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/kallisto.wdl
+++ b/definitions/tools/kallisto.wdl
@@ -10,7 +10,6 @@ task kallisto {
   Int cores = 8
   Int space_needed_gb = 10 + round(size(flatten(fastqs), "GB") + size(kallisto_index, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/kallisto.wdl
+++ b/definitions/tools/kallisto.wdl
@@ -10,6 +10,8 @@ task kallisto {
   Int cores = 8
   Int space_needed_gb = 10 + round(size(flatten(fastqs), "GB") + size(kallisto_index, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "32GB"
     cpu: cores
     docker: "quay.io/biocontainers/kallisto:0.46.1--h4f7b962_0"

--- a/definitions/tools/kallisto.wdl
+++ b/definitions/tools/kallisto.wdl
@@ -10,6 +10,7 @@ task kallisto {
   Int cores = 8
   Int space_needed_gb = 10 + round(size(flatten(fastqs), "GB") + size(kallisto_index, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "32GB"

--- a/definitions/tools/manta_somatic.wdl
+++ b/definitions/tools/manta_somatic.wdl
@@ -21,6 +21,8 @@ task mantaSomatic {
   Float regions_size = size([call_regions, call_regions_tbi], "GB")
   Int size_needed_gb = 10 + 2 * round(ref_size + bam_size + regions_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/manta_somatic-cwl:1.6.0"
     cpu: cores
     memory: "24GB"

--- a/definitions/tools/manta_somatic.wdl
+++ b/definitions/tools/manta_somatic.wdl
@@ -21,7 +21,6 @@ task mantaSomatic {
   Float regions_size = size([call_regions, call_regions_tbi], "GB")
   Int size_needed_gb = 10 + 2 * round(ref_size + bam_size + regions_size)
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/manta_somatic.wdl
+++ b/definitions/tools/manta_somatic.wdl
@@ -21,6 +21,7 @@ task mantaSomatic {
   Float regions_size = size([call_regions, call_regions_tbi], "GB")
   Int size_needed_gb = 10 + 2 * round(ref_size + bam_size + regions_size)
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/manta_somatic.wdl
+++ b/definitions/tools/manta_somatic.wdl
@@ -21,6 +21,7 @@ task mantaSomatic {
   Float regions_size = size([call_regions, call_regions_tbi], "GB")
   Int size_needed_gb = 10 + 2 * round(ref_size + bam_size + regions_size)
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/manta_somatic-cwl:1.6.0"

--- a/definitions/tools/manta_somatic.wdl
+++ b/definitions/tools/manta_somatic.wdl
@@ -21,7 +21,6 @@ task mantaSomatic {
   Float regions_size = size([call_regions, call_regions_tbi], "GB")
   Int size_needed_gb = 10 + 2 * round(ref_size + bam_size + regions_size)
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/manta_somatic-cwl:1.6.0"

--- a/definitions/tools/mark_duplicates_and_sort.wdl
+++ b/definitions/tools/mark_duplicates_and_sort.wdl
@@ -11,6 +11,7 @@ task markDuplicatesAndSort {
   #markdup is listed as 2Gb per 100M reads
   Int mem_needed_gb = round(((size(bam, "GB")*15)/100)*2)+32
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/mark_duplicates_and_sort.wdl
+++ b/definitions/tools/mark_duplicates_and_sort.wdl
@@ -11,7 +11,6 @@ task markDuplicatesAndSort {
   #markdup is listed as 2Gb per 100M reads
   Int mem_needed_gb = round(((size(bam, "GB")*15)/100)*2)+32
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/mark_duplicates_and_sort.wdl
+++ b/definitions/tools/mark_duplicates_and_sort.wdl
@@ -11,6 +11,7 @@ task markDuplicatesAndSort {
   #markdup is listed as 2Gb per 100M reads
   Int mem_needed_gb = round(((size(bam, "GB")*15)/100)*2)+32
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/sambamba:0.8.2--h98b6b92_2"

--- a/definitions/tools/mark_duplicates_and_sort.wdl
+++ b/definitions/tools/mark_duplicates_and_sort.wdl
@@ -11,7 +11,6 @@ task markDuplicatesAndSort {
   #markdup is listed as 2Gb per 100M reads
   Int mem_needed_gb = round(((size(bam, "GB")*15)/100)*2)+32
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "quay.io/biocontainers/sambamba:0.8.2--h98b6b92_2"

--- a/definitions/tools/mark_duplicates_and_sort.wdl
+++ b/definitions/tools/mark_duplicates_and_sort.wdl
@@ -11,6 +11,8 @@ task markDuplicatesAndSort {
   #markdup is listed as 2Gb per 100M reads
   Int mem_needed_gb = round(((size(bam, "GB")*15)/100)*2)+32
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/sambamba:0.8.2--h98b6b92_2"
     memory: "~{mem_needed_gb}GB"
     cpu: 16

--- a/definitions/tools/merge_bams.wdl
+++ b/definitions/tools/merge_bams.wdl
@@ -10,6 +10,8 @@ task mergeBams {
   Int cores = 4
   Int space_needed_gb = 10 + round(4*size(bams, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/bam-merge:0.1"
     memory: "8GB"
     cpu: cores

--- a/definitions/tools/merge_bams.wdl
+++ b/definitions/tools/merge_bams.wdl
@@ -10,7 +10,6 @@ task mergeBams {
   Int cores = 4
   Int space_needed_gb = 10 + round(4*size(bams, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/merge_bams.wdl
+++ b/definitions/tools/merge_bams.wdl
@@ -10,6 +10,7 @@ task mergeBams {
   Int cores = 4
   Int space_needed_gb = 10 + round(4*size(bams, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bam-merge:0.1"

--- a/definitions/tools/merge_bams.wdl
+++ b/definitions/tools/merge_bams.wdl
@@ -10,7 +10,6 @@ task mergeBams {
   Int cores = 4
   Int space_needed_gb = 10 + round(4*size(bams, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bam-merge:0.1"

--- a/definitions/tools/merge_bams.wdl
+++ b/definitions/tools/merge_bams.wdl
@@ -10,6 +10,7 @@ task mergeBams {
   Int cores = 4
   Int space_needed_gb = 10 + round(4*size(bams, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/merge_vcf.wdl
+++ b/definitions/tools/merge_vcf.wdl
@@ -9,7 +9,6 @@ task mergeVcf {
 
   Int space_needed_gb = 10 + round(2*(size(vcfs, "GB") + size(vcf_tbis, "GB")))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bcftools-cwl:1.12"

--- a/definitions/tools/merge_vcf.wdl
+++ b/definitions/tools/merge_vcf.wdl
@@ -9,6 +9,7 @@ task mergeVcf {
 
   Int space_needed_gb = 10 + round(2*(size(vcfs, "GB") + size(vcf_tbis, "GB")))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/bcftools-cwl:1.12"

--- a/definitions/tools/merge_vcf.wdl
+++ b/definitions/tools/merge_vcf.wdl
@@ -9,6 +9,8 @@ task mergeVcf {
 
   Int space_needed_gb = 10 + round(2*(size(vcfs, "GB") + size(vcf_tbis, "GB")))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/bcftools-cwl:1.12"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/merge_vcf.wdl
+++ b/definitions/tools/merge_vcf.wdl
@@ -9,7 +9,6 @@ task mergeVcf {
 
   Int space_needed_gb = 10 + round(2*(size(vcfs, "GB") + size(vcf_tbis, "GB")))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/merge_vcf.wdl
+++ b/definitions/tools/merge_vcf.wdl
@@ -9,6 +9,7 @@ task mergeVcf {
 
   Int space_needed_gb = 10 + round(2*(size(vcfs, "GB") + size(vcf_tbis, "GB")))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/mutect.wdl
+++ b/definitions/tools/mutect.wdl
@@ -26,7 +26,6 @@ task mutect {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + 2*bam_size + size(interval_list, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/mutect.wdl
+++ b/definitions/tools/mutect.wdl
@@ -26,6 +26,7 @@ task mutect {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + 2*bam_size + size(interval_list, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.2.3.0"

--- a/definitions/tools/mutect.wdl
+++ b/definitions/tools/mutect.wdl
@@ -26,7 +26,6 @@ task mutect {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + 2*bam_size + size(interval_list, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "broadinstitute/gatk:4.2.3.0"

--- a/definitions/tools/mutect.wdl
+++ b/definitions/tools/mutect.wdl
@@ -26,6 +26,7 @@ task mutect {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + 2*bam_size + size(interval_list, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/mutect.wdl
+++ b/definitions/tools/mutect.wdl
@@ -26,6 +26,8 @@ task mutect {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + 2*bam_size + size(interval_list, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "broadinstitute/gatk:4.2.3.0"
     memory: "2GB"
     bootDiskSizeGb: space_needed_gb

--- a/definitions/tools/name_sort.wdl
+++ b/definitions/tools/name_sort.wdl
@@ -9,7 +9,6 @@ task nameSort {
 
   Int input_size_gb = 10 + 5*round(size(bam, "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/name_sort.wdl
+++ b/definitions/tools/name_sort.wdl
@@ -9,7 +9,6 @@ task nameSort {
 
   Int input_size_gb = 10 + 5*round(size(bam, "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/sambamba-cwl:0.6.4"

--- a/definitions/tools/name_sort.wdl
+++ b/definitions/tools/name_sort.wdl
@@ -9,6 +9,8 @@ task nameSort {
 
   Int input_size_gb = 10 + 5*round(size(bam, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/sambamba-cwl:0.6.4"
     memory: "26GB"
     cpu: cores

--- a/definitions/tools/name_sort.wdl
+++ b/definitions/tools/name_sort.wdl
@@ -9,6 +9,7 @@ task nameSort {
 
   Int input_size_gb = 10 + 5*round(size(bam, "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     docker: "mgibio/sambamba-cwl:0.6.4"

--- a/definitions/tools/name_sort.wdl
+++ b/definitions/tools/name_sort.wdl
@@ -9,6 +9,7 @@ task nameSort {
 
   Int input_size_gb = 10 + 5*round(size(bam, "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/normalize_variants.wdl
+++ b/definitions/tools/normalize_variants.wdl
@@ -12,6 +12,7 @@ task normalizeVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB") + size([reference, reference_fai, reference_dict], "GB"))
   runtime {
+    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/normalize_variants.wdl
+++ b/definitions/tools/normalize_variants.wdl
@@ -12,6 +12,7 @@ task normalizeVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB") + size([reference, reference_fai, reference_dict], "GB"))
   runtime {
+    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/normalize_variants.wdl
+++ b/definitions/tools/normalize_variants.wdl
@@ -12,7 +12,6 @@ task normalizeVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB") + size([reference, reference_fai, reference_dict], "GB"))
   runtime {
-    useDockerImageCache: true
     noAddress: true
     preemptible: 1
     maxRetries: 2

--- a/definitions/tools/normalize_variants.wdl
+++ b/definitions/tools/normalize_variants.wdl
@@ -12,7 +12,6 @@ task normalizeVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB") + size([reference, reference_fai, reference_dict], "GB"))
   runtime {
-    noAddress: true
     preemptible: 1
     maxRetries: 2
     memory: "9GB"

--- a/definitions/tools/normalize_variants.wdl
+++ b/definitions/tools/normalize_variants.wdl
@@ -12,6 +12,8 @@ task normalizeVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB") + size([reference, reference_fai, reference_dict], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     docker: "broadinstitute/gatk:4.1.8.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/optitype_dna.wdl
+++ b/definitions/tools/optitype_dna.wdl
@@ -13,6 +13,8 @@ task optitypeDna {
 
   Int space_needed_gb = 10 + round(5*size([cram, cram_crai, reference, reference_fai], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "~{mem}GB"
     cpu: threads 
     docker: "mgibio/immuno_tools-cwl:1.0.2"

--- a/definitions/tools/phlat.wdl
+++ b/definitions/tools/phlat.wdl
@@ -14,6 +14,8 @@ task phlat {
 
   Int space_needed_gb = 10 + round(5*size([cram, cram_crai, reference, reference_fai], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "~{mem}GB"
     cpu: nthreads
     docker: "mgibio/phlat:1.1_withindex"

--- a/definitions/tools/picard_merge_vcfs.wdl
+++ b/definitions/tools/picard_merge_vcfs.wdl
@@ -9,6 +9,8 @@ task picardMergeVcfs {
 
   Int space_needed_gb = 10 + round(size(sequence_dictionary, "GB") + size(vcfs, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "40GB"
     docker: "broadinstitute/gatk:4.1.8.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/pindel.wdl
+++ b/definitions/tools/pindel.wdl
@@ -19,6 +19,8 @@ task pindel {
   Int cores = 4
   Int space_needed_gb = 10 + round(size([reference, reference_fai, reference_dict, normal_bam, normal_bam_bai, tumor_bam, tumor_bam_bai, region_file], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     bootDiskSizeGb: 100
     cpu: cores
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/pindel_somatic_filter.wdl
+++ b/definitions/tools/pindel_somatic_filter.wdl
@@ -10,6 +10,8 @@ task pindelSomaticFilter {
 
   Int space_needed_gb = 10 + round(size([reference, reference_fai, reference_dict, pindel_output_summary], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "16GB"
     docker: "mgibio/cle:v1.3.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/pvacfuse.wdl
+++ b/definitions/tools/pvacfuse.wdl
@@ -27,6 +27,8 @@ task pvacfuse {
 
   Int space_needed_gb = 10 + round(size([input_fusions_zip], "GB") * 3)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "griffithlab/pvactools:3.1.0"
     memory: "16GB"
     cpu: n_threads

--- a/definitions/tools/pvacseq.wdl
+++ b/definitions/tools/pvacseq.wdl
@@ -48,6 +48,8 @@ task pvacseq {
   Float phased_variants_size = size([phased_proximal_variants_vcf, phased_proximal_variants_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(input_size + phased_variants_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "16GB"
     cpu: n_threads
     docker: "griffithlab/pvactools:3.1.0"

--- a/definitions/tools/pvacseq_combine_variants.wdl
+++ b/definitions/tools/pvacseq_combine_variants.wdl
@@ -15,6 +15,8 @@ task pvacseqCombineVariants {
   Float vcf_size = size([germline_vcf, germline_vcf_tbi, somatic_vcf, somatic_vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(reference_size + 2*vcf_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "9GB"
     bootDiskSizeGb: 25
     docker: "mgibio/gatk-cwl:3.6.0"

--- a/definitions/tools/read_backed_phasing.wdl
+++ b/definitions/tools/read_backed_phasing.wdl
@@ -13,6 +13,8 @@ task readBackedPhasing {
 
   Int space_needed_gb = 10 + round(size([bam, bam_index, reference, reference_fai, reference_dict, vcf, vcf_tbi], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/gatk-cwl:3.6.0"
     memory: "9GB"
     bootDiskSizeGb: 25

--- a/definitions/tools/remove_end_tags.wdl
+++ b/definitions/tools/remove_end_tags.wdl
@@ -8,6 +8,8 @@ task removeEndTags {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibio/bcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/replace_vcf_sample_name.wdl
+++ b/definitions/tools/replace_vcf_sample_name.wdl
@@ -9,6 +9,8 @@ task replaceVcfSampleName {
 
   Int space_needed_gb = 10 + round(size(input_vcf, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "8GB"
     docker: "mgibio/bcftools-cwl:1.12"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/samtools_flagstat.wdl
+++ b/definitions/tools/samtools_flagstat.wdl
@@ -13,6 +13,8 @@ task samtoolsFlagstat {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai], "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/samtools_sort.wdl
+++ b/definitions/tools/samtools_sort.wdl
@@ -9,6 +9,8 @@ task samtoolsSort {
   Int cores = 1
   Int space_needed_gb = 10 + round(3*size(input_bam, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     cpu: cores
     docker: "quay.io/biocontainers/samtools:1.11--h6270b1f_0"

--- a/definitions/tools/script.sh
+++ b/definitions/tools/script.sh
@@ -1,2 +1,0 @@
-sed -i'' -e 's/runtime {\n    preemptible: 1\n    maxRetries: 2/n    preemptible: 1\n    maxRetries: 2/n    preemptible: 1\n    maxRetries: 2/runtime {\n    preemptible: 1\n    maxRetries: 2/g' *
-

--- a/definitions/tools/script.sh
+++ b/definitions/tools/script.sh
@@ -1,0 +1,2 @@
+sed -i'' -e 's/runtime {\n    preemptible: 1\n    maxRetries: 2/n    preemptible: 1\n    maxRetries: 2/n    preemptible: 1\n    maxRetries: 2/runtime {\n    preemptible: 1\n    maxRetries: 2/g' *
+

--- a/definitions/tools/select_variants.wdl
+++ b/definitions/tools/select_variants.wdl
@@ -25,6 +25,8 @@ task selectVariants {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB")*3 + size([reference, reference_fai, reference_dict, interval_list], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "broadinstitute/gatk:4.1.8.1"
     memory: "6GB"
     bootDiskSizeGb: 25

--- a/definitions/tools/sequence_align_and_tag.wdl
+++ b/definitions/tools/sequence_align_and_tag.wdl
@@ -28,6 +28,8 @@ task sequenceAlignAndTag {
   Int instance_memory_gb = 76 
   Int jvm_memory_gb = 4
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/alignment_helper-cwl:2.2.1"
     memory: "~{instance_memory_gb}GB"
     cpu: cores

--- a/definitions/tools/sequence_to_fastq.wdl
+++ b/definitions/tools/sequence_to_fastq.wdl
@@ -13,6 +13,8 @@ task sequenceToFastq {
   Int compression_multiplier = if unzip_fastqs then 10 else 1
   Int space_needed_gb = 10 + ceil(2*compression_multiplier*size([bam, fastq1, fastq2], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "16GB"
     bootDiskSizeGb: 25
     docker: "broadinstitute/picard:2.23.6"

--- a/definitions/tools/set_filter_status.wdl
+++ b/definitions/tools/set_filter_status.wdl
@@ -15,6 +15,8 @@ task setFilterStatus {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + vcf_size*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     disks: "local-disk ~{space_needed_gb} HDD"
     memory: "6GB"
     bootDiskSizeGb: 25

--- a/definitions/tools/single_sample_docm_filter.wdl
+++ b/definitions/tools/single_sample_docm_filter.wdl
@@ -7,6 +7,8 @@ task singleSampleDocmFilter {
 
   Int space_needed_gb = 10 + round(size(docm_out, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibio/perl_helper-cwl:1.0.0"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/smoove.wdl
+++ b/definitions/tools/smoove.wdl
@@ -14,6 +14,8 @@ task smoove {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(2*(size(bams, "GB") + reference_size))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "20GB"
     cpu: cores
     bootDiskSizeGb: 10

--- a/definitions/tools/sort_vcf.wdl
+++ b/definitions/tools/sort_vcf.wdl
@@ -8,6 +8,8 @@ task sortVcf {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB") + size(reference_dict, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "18GB"
     docker: "broadinstitute/picard:2.23.6"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/split_interval_list.wdl
+++ b/definitions/tools/split_interval_list.wdl
@@ -8,6 +8,8 @@ task splitIntervalList {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "broadinstitute/picard:2.24.2"
     memory: "6GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/split_interval_list_to_bed.wdl
+++ b/definitions/tools/split_interval_list_to_bed.wdl
@@ -8,6 +8,8 @@ task splitIntervalListToBed {
 
   Int space_needed_gb = 10 + round(size(interval_list, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "6GB"
     docker: "mgibio/cle:v1.4.2"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/staged_rename.wdl
+++ b/definitions/tools/staged_rename.wdl
@@ -8,6 +8,8 @@ task stagedRename {
 
   Int space_needed_gb = 10 + round(size(original, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     cpu: 1
     docker: "ubuntu:bionic"

--- a/definitions/tools/star_align_fusion.wdl
+++ b/definitions/tools/star_align_fusion.wdl
@@ -37,6 +37,8 @@ task starAlignFusion {
   Float fastq_size = size(flatten([fastq, fastq2]), "GB")
   Int space_needed_gb = 10 + round(2 * (zip_size + fastq_size))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     cpu: cores
     memory: "64GB"
     docker: "trinityctat/starfusion:1.10.1"

--- a/definitions/tools/star_fusion_detect.wdl
+++ b/definitions/tools/star_fusion_detect.wdl
@@ -18,6 +18,8 @@ task starFusionDetect {
   Float fastq_size = size(flatten([fastq, fastq2]), "GB")
   Int space_needed_gb = 10 + round(3 * (zip_size + fastq_size))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "64GB"
     cpu: cores
     docker: "trinityctat/starfusion:pre-1.11.c"

--- a/definitions/tools/strandedness_check.wdl
+++ b/definitions/tools/strandedness_check.wdl
@@ -11,6 +11,8 @@ task strandednessCheck {
 
   Int space_needed_gb = 10 + round(2*size([reference_annotation, kallisto_index, cdna_fasta, reads1, reads2], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "16GB"
     bootDiskSizeGb: space_needed_gb  # default
     cpu: 1

--- a/definitions/tools/strelka.wdl
+++ b/definitions/tools/strelka.wdl
@@ -21,6 +21,8 @@ task strelka {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + round(bam_size*2 + reference_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     cpu: 4
     docker: "mgibio/strelka-cwl:2.9.9"

--- a/definitions/tools/stringtie.wdl
+++ b/definitions/tools/stringtie.wdl
@@ -11,6 +11,8 @@ task stringtie {
   Int cores = 12
   Int space_needed_gb = 10 + round(size([bam, reference_annotation], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "16GB"
     cpu: cores
     docker: "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"

--- a/definitions/tools/survivor.wdl
+++ b/definitions/tools/survivor.wdl
@@ -14,6 +14,8 @@ task survivor {
 
   Int space_needed_gb = 10
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/survivor-cwl:1.0.6.2"
     memory: "2GB"
     cpu: 1

--- a/definitions/tools/transcript_to_gene.wdl
+++ b/definitions/tools/transcript_to_gene.wdl
@@ -8,6 +8,8 @@ task transcriptToGene {
 
   Int space_needed_gb = 10 + round(size([transcript_table_h5, gene_transcript_lookup_table], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "2GB"
     cpu: 1
     docker: "mgibio/rnaseq:1.0.0"

--- a/definitions/tools/trim_fastq.wdl
+++ b/definitions/tools/trim_fastq.wdl
@@ -14,6 +14,8 @@ task trimFastq {
   Int cores = 4
   Int space_needed_gb = 10 + ceil(size(adapters, "GB") + 10*size([reads1, reads2], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "16GB"
     bootDiskSizeGb: 25
     cpu: 4

--- a/definitions/tools/variants_to_table.wdl
+++ b/definitions/tools/variants_to_table.wdl
@@ -20,6 +20,8 @@ task variantsToTable {
   Float vcf_size = size([vcf, vcf_tbi], "GB")
   Int space_needed_gb = 10 + round(vcf_size*2 + reference_size)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "6GB"
     bootDiskSizeGb: 25
     docker: "broadinstitute/gatk:4.1.8.1"

--- a/definitions/tools/varscan_germline.wdl
+++ b/definitions/tools/varscan_germline.wdl
@@ -18,6 +18,8 @@ task varscanGermline {
 
   Int space_needed_gb = 10
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "12GB"
     cpu: 2
     docker: "mgibio/varscan_helper-cwl:1.0.0"

--- a/definitions/tools/varscan_process_somatic.wdl
+++ b/definitions/tools/varscan_process_somatic.wdl
@@ -8,6 +8,8 @@ task varscanProcessSomatic {
 
   Int space_needed_gb = 10 + round(size(variants, "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "mgibio/cle:v1.3.1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/varscan_somatic.wdl
+++ b/definitions/tools/varscan_somatic.wdl
@@ -23,6 +23,8 @@ task varscanSomatic {
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + bam_size*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "12GB"
     cpu: 2
     docker: "mgibio/cle:v1.3.1"

--- a/definitions/tools/vcf_expression_annotator.wdl
+++ b/definitions/tools/vcf_expression_annotator.wdl
@@ -11,6 +11,8 @@ task vcfExpressionAnnotator {
 
   Int space_needed_gb = 10 + round(2*size([vcf, expression_file], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "griffithlab/vatools:4.1.0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/vcf_readcount_annotator.wdl
+++ b/definitions/tools/vcf_readcount_annotator.wdl
@@ -11,6 +11,8 @@ task vcfReadcountAnnotator {
 
   Int space_needed_gb = 10 + round(size(vcf, "GB")*2 + size(bam_readcount_tsv, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "griffithlab/vatools:4.1.0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/vcf_sanitize.wdl
+++ b/definitions/tools/vcf_sanitize.wdl
@@ -6,6 +6,8 @@ task vcfSanitize {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     cpu: 1
     docker: "mgibio/samtools-cwl:1.0.0"

--- a/definitions/tools/vep.wdl
+++ b/definitions/tools/vep.wdl
@@ -31,6 +31,8 @@ task vepTask {
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Int space_needed_gb = 10 + round(reference_size + vcf_size + cache_size + size(synonyms_file, "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "64GB"
     bootDiskSizeGb: 30
     cpu: 4
@@ -83,7 +85,9 @@ task vepTask {
 # happen in WDL instead of a task
 task parseVepCustomAnnotationIntoArg {
   input { VepCustomAnnotation obj }
-  runtime { docker: "python:3.10" }
+  runtime {
+    preemptible: 1
+    maxRetries: 2 docker: "python:3.10" }
   command <<<
     python <<CODE
     check_existing = "~{true="--check_existing" false="" obj.annotation.check_existing}"

--- a/definitions/tools/vep.wdl
+++ b/definitions/tools/vep.wdl
@@ -87,7 +87,9 @@ task parseVepCustomAnnotationIntoArg {
   input { VepCustomAnnotation obj }
   runtime {
     preemptible: 1
-    maxRetries: 2 docker: "python:3.10" }
+    maxRetries: 2 
+    docker: "python:3.10" 
+  }
   command <<<
     python <<CODE
     check_existing = "~{true="--check_existing" false="" obj.annotation.check_existing}"

--- a/definitions/tools/verify_bam_id.wdl
+++ b/definitions/tools/verify_bam_id.wdl
@@ -9,6 +9,8 @@ task verifyBamId {
 
   Int space_needed_gb = 10 + round(size([bam, bam_bai, vcf], "GB"))
   runtime {
+    preemptible: 1
+    maxRetries: 2
     docker: "mgibio/verify_bam_id-cwl:1.1.3"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/vt_decompose.wdl
+++ b/definitions/tools/vt_decompose.wdl
@@ -8,6 +8,8 @@ task vtDecompose {
 
   Int space_needed_gb = 10 + round(size([vcf, vcf_tbi], "GB")*2)
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "4GB"
     docker: "quay.io/biocontainers/vt:0.57721--hf74b74d_1"
     disks: "local-disk ~{space_needed_gb} HDD"

--- a/definitions/tools/xenosplit.wdl
+++ b/definitions/tools/xenosplit.wdl
@@ -7,6 +7,8 @@ task xenosplit {
   }
 
   runtime {
+    preemptible: 1
+    maxRetries: 2
     memory: "20GB"
     bootDiskSizeGb: 100
     docker: "mgibio/xenosplit:0.5"


### PR DESCRIPTION
`sed -i'' -e 's/runtime {/runtime {\n    <attribute_name>:<value>/g' *.wdl`
4 white spaces between `/n` and `<`


- [x] preemptible
- [x] maxRetries
- [x] `bqsr.wdl` case and similar ones ... (seems to already have a `preemptible` parameter associated with an input value)
- [x] `vep.wdl`