### PR TITLE
Update docker image to 0.5.4 for handling of case of 0-depth variant.

### DIFF
--- a/definitions/tools/filter_vcf_mapq0.wdl
+++ b/definitions/tools/filter_vcf_mapq0.wdl
@@ -14,7 +14,7 @@ task filterVcfMapq0 {
   runtime {
     preemptible: 1
     maxRetries: 2
-    docker: "mgibio/mapq0-filter:v0.5.3"
+    docker: "mgibio/mapq0-filter:v0.5.4"
     memory: "8GB"
     bootDiskSizeGb: 10
     disks: "local-disk ~{space_needed_gb} HDD"


### PR DESCRIPTION
https://hub.docker.com/layers/mgibio/mapq0-filter/v0.5.4/images/sha256-ef5046b3e74bd1689fbf599c2731031213f9436061f791b909bc77779e2137d2?context=explore