### PR TITLE
Switch to patched version of star fusion to handle readgroup tag option.

### DIFF
--- a/definitions/tools/star_fusion_detect.wdl
+++ b/definitions/tools/star_fusion_detect.wdl
@@ -22,7 +22,7 @@ task starFusionDetect {
     maxRetries: 2
     memory: "64GB"
     cpu: cores
-    docker: "trinityctat/starfusion:pre-1.11.c"
+    docker: "mgibio/starfusion:pre-1.11.c-fefaf71"
     disks: "local-disk ~{space_needed_gb} HDD"
   }
 


### PR DESCRIPTION
This backports STAR-Fusion/STAR-Fusion#345 to the version we're currently using in the pipeline.