### PR TITLE
Add localization optional to varscan somatic.

### DIFF
--- a/definitions/tools/varscan_process_somatic.wdl
+++ b/definitions/tools/varscan_process_somatic.wdl
@@ -11,7 +11,7 @@ task varscanProcessSomatic {
     preemptible: 1
     maxRetries: 2
     memory: "4GB"
-    docker: "mgibio/cle:v1.3.1"
+    docker: "mgibio/varscan-cwl:v2.4.2-samtools1.16.1"
     disks: "local-disk ~{space_needed_gb} HDD"
   }
 


### PR DESCRIPTION
This required building a newer image with varscan and a newer samtools that supports reading `gs://` URLs.

There are some differences in the varscan output as a result of this change.  The most dramatic change comes not from upgrading to 1.16.1 but from switching from the custom samtools 1.3.1/htslib 1.3.2 combo in the CLE image to any other version I tried (1.3.1 and 1.7). So not sure if there's something special about the combination in the CLE image...

This is part of #64.