### PR TITLE
use pipe instead of redirection for varscan

### DIFF
--- a/definitions/tools/varscan_somatic.wdl
+++ b/definitions/tools/varscan_somatic.wdl
@@ -19,13 +19,6 @@ task varscanSomatic {
     File? roi_bed
   }
 
-  parameter_meta {
-    tumor_bam: { localization_optional: true }
-    tumor_bam_bai: { localization_optional: true }
-    normal_bam: { localization_optional: true }
-    normal_bam_bai: { localization_optional: true }
-  }
-
   Float reference_size = size([reference, reference_fai, reference_dict], "GB")
   Float bam_size = size([tumor_bam, tumor_bam_bai, normal_bam, normal_bam_bai], "GB")
   Int space_needed_gb = 10 + ceil(reference_size + bam_size*2)


### PR DESCRIPTION
Even if we do `set -o pipefail` as proposed here, a failed read when streaming directly from a google bucket is not caught when the varscan command is using redirection.  

For that reason, this pull request also changes the VarScan command to use a pipe instead. 