### PR TITLE
Upgrade to version 5.1.0

### DIFF
--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -13,7 +13,7 @@ task addVepFieldsToTable {
     preemptible: 1
     maxRetries: 2
     memory: "4GB"
-    docker: "griffithlab/vatools:4.1.0"
+    docker: "griffithlab/vatools:5.1.0"
     disks: "local-disk ~{space_needed_gb} HDD"
   }
 

--- a/definitions/tools/vcf_expression_annotator.wdl
+++ b/definitions/tools/vcf_expression_annotator.wdl
@@ -13,7 +13,7 @@ task vcfExpressionAnnotator {
   runtime {
     preemptible: 1
     maxRetries: 2
-    docker: "griffithlab/vatools:4.1.0"
+    docker: "griffithlab/vatools:5.1.0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"
   }

--- a/definitions/tools/vcf_readcount_annotator.wdl
+++ b/definitions/tools/vcf_readcount_annotator.wdl
@@ -13,7 +13,7 @@ task vcfReadcountAnnotator {
   runtime {
     preemptible: 1
     maxRetries: 2
-    docker: "griffithlab/vatools:4.1.0"
+    docker: "griffithlab/vatools:5.1.0"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"
   }


### PR DESCRIPTION
This version introduces a few bugfixes and changes:
- The vcf-expression-annotator now uses the gene column in order to match up entries by Ensembl gene ID (https://github.com/griffithlab/VAtools/pull/66)
- The vcf-readcount-annotator now also annotates forward and reverses strand allele counts (https://github.com/griffithlab/VAtools/pull/72)

The Docker container is now based on the python 3.11 base image (instead of ubuntu) so that might introduce some subtle differences although I don't believe any changes are necessary in how we call the tools.

Due to these somewhat extensive changes, I would suggest to do a test immuno.wdl run before merging.