### PR TITLE
Change to test release VAtools image for version 5.2.1

### DIFF
--- a/definitions/tools/add_vep_fields_to_table.wdl
+++ b/definitions/tools/add_vep_fields_to_table.wdl
@@ -14,7 +14,7 @@ task addVepFieldsToTable {
     preemptible: 1
     maxRetries: 2
     memory: "4GB"
-    docker: "griffithlab/vatools:5.2.0"
+    docker: "susannakiwala/vatools:5.2.1"
     disks: "local-disk ~{space_needed_gb} HDD"
   }
 

--- a/definitions/tools/vcf_expression_annotator.wdl
+++ b/definitions/tools/vcf_expression_annotator.wdl
@@ -13,7 +13,7 @@ task vcfExpressionAnnotator {
   runtime {
     preemptible: 1
     maxRetries: 2
-    docker: "griffithlab/vatools:5.2.0"
+    docker: "susannakiwala/vatools:5.2.1"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"
   }

--- a/definitions/tools/vcf_readcount_annotator.wdl
+++ b/definitions/tools/vcf_readcount_annotator.wdl
@@ -13,7 +13,7 @@ task vcfReadcountAnnotator {
   runtime {
     preemptible: 1
     maxRetries: 2
-    docker: "griffithlab/vatools:5.2.0"
+    docker: "susannakiwala/vatools:5.2.1"
     memory: "4GB"
     disks: "local-disk ~{space_needed_gb} HDD"
   }


### PR DESCRIPTION
This upcoming VAtools release [updates the VCFpy dependency to a newer version](https://github.com/griffithlab/VAtools/pull/84) which no longer encodes certain special characters. As a result, the output VCFs generated with these steps may be formatted differently than expected in downstream step. This PR needs to go through the usual Immuno WDL tests to ensure there are no unintended downstream consequences. 

Once we confirm that this change will still work as expected, I will make an official release and update the PR to point to the official docker image.